### PR TITLE
[refactor] ServiceCatalog 관련 기획과 다른 부분들 수정

### DIFF
--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -45,6 +45,22 @@ const serviceInstanceStatusReducer = (serviceInstance: any): string => {
   return serviceInstance.status.lastConditionState;
 };
 
+const ClusterServiceBrokerPhase = instance => {
+  let phase = '';
+  if (instance.status) {
+    instance.status.conditions.forEach(cur => {
+      if (cur.type === 'Ready') {
+        if (cur.status === 'True') {
+          phase = 'Running';
+        } else {
+          phase = 'Error';
+        }
+      }
+    });
+    return phase;
+  }
+};
+
 const pipelineApprovalStatusReducer = (pipelineApproval: any): string => {
   return pipelineApproval.status.result;
 };
@@ -233,6 +249,14 @@ export const tableFilters: TableFilterMap = {
     }
 
     const phase = serviceInstanceStatusReducer(serviceInstance);
+    return phases.selected.has(phase) || !_.includes(phases.all, phase);
+  },
+  'cluster-service-broker-status': (phases, clusterServiceBroker) => {
+    if (!phases || !phases.selected || !phases.selected.size) {
+      return true;
+    }
+
+    const phase = ClusterServiceBrokerPhase(clusterServiceBroker);
     return phases.selected.has(phase) || !_.includes(phases.all, phase);
   },
 

--- a/frontend/public/components/hypercloud/cluster-service-broker.tsx
+++ b/frontend/public/components/hypercloud/cluster-service-broker.tsx
@@ -23,7 +23,7 @@ const ClusterServiceBrokerDetails: React.FC<ClusterServiceBrokerDetailsProps> = 
         <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(clusterServiceBroker, t) })} />
         <div className="row">
           <div className="col-md-6">
-            <ResourceSummary resource={clusterServiceBroker} showOwner={false}></ResourceSummary>
+            <ResourceSummary resource={clusterServiceBroker} showOwner={false} showAnnotations={false}></ResourceSummary>
           </div>
           <div className="col-md-6">
             <dl className="co-m-pane__details">
@@ -45,16 +45,17 @@ type ClusterServiceBrokerDetailsProps = {
 };
 
 const { details, editResource } = navFactory;
-const ClusterServiceBrokersDetailsPage: React.FC<ClusterServiceBrokersDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={clusterServiceBrokerMenuActions} pages={[details(ClusterServiceBrokerDetails), editResource()]} />;
+const ClusterServiceBrokersDetailsPage: React.FC<ClusterServiceBrokersDetailsPageProps> = props => <DetailsPage {...props} kind={kind} getResourceStatus={ClusterServiceBrokerPhase} menuActions={clusterServiceBrokerMenuActions} pages={[details(ClusterServiceBrokerDetails), editResource()]} />;
 ClusterServiceBrokersDetailsPage.displayName = 'ClusterServiceBrokersDetailsPage';
 
 const tableColumnClasses = [
   '', // NAME
-  '', // URL
-  classNames('pf-m-hidden', 'pf-m-visible-on-sm'), // STATUS
+  '', // STATUS
+  classNames('pf-m-hidden', 'pf-m-visible-on-sm'), // URL
   classNames('pf-m-hidden', 'pf-m-visible-on-lg'), // CREATED
   Kebab.columnClass, // MENU ACTIONS
 ];
+
 const ClusterServiceBrokerPhase = instance => {
   let phase = '';
   if (instance.status) {
@@ -78,10 +79,10 @@ const ClusterServiceBrokerTableRow = ({ obj, index, key, style }) => {
       <TableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={obj.metadata.name} title={obj.metadata.name} />
       </TableData>
-      <TableData className={tableColumnClasses[1]}>{obj.spec.url}</TableData>
-      <TableData className={tableColumnClasses[2]}>
+      <TableData className={tableColumnClasses[1]}>
         <Status status={phase} />
       </TableData>
+      <TableData className={tableColumnClasses[2]}>{obj.spec.url}</TableData>
       <TableData className={tableColumnClasses[3]}>
         <Timestamp timestamp={obj.metadata.creationTimestamp} />
       </TableData>
@@ -101,14 +102,14 @@ const ClusterServiceBrokerTableHeader = (t?: TFunction) => {
       props: { className: tableColumnClasses[0] },
     },
     {
-      title: t('COMMON:MSG_MAIN_TABLEHEADER_4'),
-      sortField: 'spec.url',
+      title: t('COMMON:MSG_MAIN_TABLEHEADER_3'),
+      sortFunc: 'ServiceBrokerPhase',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
     },
     {
-      title: t('COMMON:MSG_MAIN_TABLEHEADER_3'),
-      sortFunc: 'ServiceBrokerPhase',
+      title: t('COMMON:MSG_MAIN_TABLEHEADER_4'),
+      sortField: 'spec.url',
       transforms: [sortable],
       props: { className: tableColumnClasses[2] },
     },
@@ -134,7 +135,28 @@ ClusterServiceBrokersList.displayName = 'ClusterServiceBrokersList';
 
 const ClusterServiceBrokersPage: React.FC<ClusterServiceBrokersPageProps> = props => {
   const { t } = useTranslation();
-  return <ListPage title={t('COMMON:MSG_LNB_MENU_14')} createButtonText={t('COMMON:MSG_MAIN_CREATEBUTTON_1', { 0: t('COMMON:MSG_LNB_MENU_14') })} canCreate={true} kind={kind} ListComponent={ClusterServiceBrokersList} {...props} />;
+  return (
+    <ListPage
+      title={t('COMMON:MSG_LNB_MENU_14')}
+      createButtonText={t('COMMON:MSG_MAIN_CREATEBUTTON_1', { 0: t('COMMON:MSG_LNB_MENU_14') })}
+      rowFilters={[
+        {
+          filterLabel: t('COMMON:MSG_COMMON_BUTTON_FILTER_3'),
+          filterGroupName: 'Status',
+          type: 'cluster-service-broker-status',
+          reducer: ClusterServiceBrokerPhase,
+          items: [
+            { id: 'Running', title: 'Running' },
+            { id: 'Error', title: 'Error' },
+          ],
+        },
+      ]}
+      canCreate={true}
+      kind={kind}
+      ListComponent={ClusterServiceBrokersList}
+      {...props}
+    />
+  );
 };
 ClusterServiceBrokersPage.displayName = 'ClusterServiceBrokersPage';
 

--- a/frontend/public/components/hypercloud/cluster-template-claim.tsx
+++ b/frontend/public/components/hypercloud/cluster-template-claim.tsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash-es';
 import { sortable } from '@patternfly/react-table';
 import { ClusterTemplateClaimModel } from '../../models';
 import { ClusterTemplateClaimKind } from '../../module/k8s';
+import { Status } from '@console/shared';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
 import { DetailsPage, ListPage, Table, TableData, TableRow } from '../factory';
@@ -22,14 +23,16 @@ const ClusterTemplateClaimDetails: React.FC<ClusterTemplateClaimDetailsProps> = 
         <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(clusterTemplateClaim, t) })} />
         <div className="row">
           <div className="col-md-6">
-            <ResourceSummary resource={clusterTemplateClaim} showOwner={false}></ResourceSummary>
+            <ResourceSummary resource={clusterTemplateClaim}></ResourceSummary>
           </div>
           <div className="col-md-6">
             <dl className="co-m-pane__details">
               <dt>{t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_118')}</dt>
               <dd>{clusterTemplateClaim.spec?.resourceName}</dd>
               <dt>{t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_13')}</dt>
-              <dd>{clusterTemplateClaim.status?.status}</dd>
+              <dd>
+                <Status status={clusterTemplateClaim.status?.status} />
+              </dd>
               <dt>{t('COMMON:MSG_DETAILS_TABDETAILS_18')}</dt>
               <dd>
                 <Timestamp timestamp={clusterTemplateClaim.status?.lastTransitionTime} />
@@ -59,12 +62,13 @@ const { details, editResource } = navFactory;
 const ClusterTemplateClaimsDetailsPage: React.FC<ClusterTemplateClaimsDetailsPageProps> = props => {
   const [status, setStatus] = React.useState();
   const menuActions = isUnmodifiable(status) ? clusterTemplateClaimCommonActions : [...clusterTemplateClaimCommonActions, Kebab.factory.ModifyStatus];
-  return <DetailsPage {...props} kind={kind} menuActions={menuActions} setState4MenuActions={setStatus} statePath='status.status' pages={[details(ClusterTemplateClaimDetails), editResource()]} />;
+  return <DetailsPage {...props} kind={kind} menuActions={menuActions} setState4MenuActions={setStatus} statePath="status.status" pages={[details(ClusterTemplateClaimDetails), editResource()]} />;
 };
 ClusterTemplateClaimsDetailsPage.displayName = 'ClusterTemplateClaimsDetailsPage';
 
 const tableColumnClasses = [
   '', // NAME
+  '', // NAMESPACE
   '', // STATUS
   '', // CREATED
   Kebab.columnClass, // MENU ACTIONS
@@ -78,6 +82,9 @@ const ClusterTemplateClaimTableRow = ({ obj, index, key, style }) => {
         <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
       </TableData>
       <TableData className={tableColumnClasses[1]}>
+        <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
         {obj.status?.status === 'Error' ? (
           <Popover headerContent={<div>에러 상세</div>} bodyContent={<div>{obj.status?.reason}</div>} maxWidth="30rem" position="right">
             <div style={{ width: 'fit-content', cursor: 'pointer', color: '#0066CC' }}>{obj.status?.status}</div>
@@ -86,10 +93,10 @@ const ClusterTemplateClaimTableRow = ({ obj, index, key, style }) => {
           obj.status?.status
         )}
       </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      <TableData className={tableColumnClasses[3]}>
         <Timestamp timestamp={obj.metadata.creationTimestamp} />
       </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      <TableData className={tableColumnClasses[4]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={obj} />
       </TableData>
     </TableRow>
@@ -105,20 +112,26 @@ const ClusterTemplateClaimTableHeader = (t?: TFunction) => {
       props: { className: tableColumnClasses[0] },
     },
     {
+      title: t('COMMON:MSG_MAIN_TABLEHEADER_2'),
+      sortField: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
       title: t('COMMON:MSG_MAIN_TABLEHEADER_3'),
       sortFunc: 'clusterTemplateClaimStatusReducer',
       transforms: [sortable],
-      props: { className: tableColumnClasses[1] },
+      props: { className: tableColumnClasses[2] },
     },
     {
       title: t('COMMON:MSG_MAIN_TABLEHEADER_12'),
       sortField: 'metadata.creationTimestamp',
       transforms: [sortable],
-      props: { className: tableColumnClasses[2] },
+      props: { className: tableColumnClasses[3] },
     },
     {
       title: '',
-      props: { className: tableColumnClasses[3] },
+      props: { className: tableColumnClasses[4] },
     },
   ];
 };

--- a/frontend/public/components/hypercloud/form/templateinstances/create-templateinstance.tsx
+++ b/frontend/public/components/hypercloud/form/templateinstances/create-templateinstance.tsx
@@ -164,7 +164,7 @@ const CreateTemplateInstanceComponent: React.FC<TemplateInstanceFormProps> = pro
         paramList?.length > 0 ? (
           <>
             <label className="control-label">{t('SINGLE:MSG_TEMPLATEINSTANCES_CREATEFORM_DIV13_1')}</label>
-            {paramList}{' '}
+            {paramList}
           </>
         ) : (
           <>

--- a/frontend/public/components/hypercloud/form/templateinstances/create-templateinstance.tsx
+++ b/frontend/public/components/hypercloud/form/templateinstances/create-templateinstance.tsx
@@ -160,7 +160,19 @@ const CreateTemplateInstanceComponent: React.FC<TemplateInstanceFormProps> = pro
         <RadioGroup name="type" items={typeItems} inline={false} initValue={selectedType} methods={methods} />
       </Section>
       {templateDropdown}
-      {paramList}
+      {!!paramList ? (
+        paramList?.length > 0 ? (
+          <>
+            <label className="control-label">{t('SINGLE:MSG_TEMPLATEINSTANCES_CREATEFORM_DIV13_1')}</label>
+            {paramList}{' '}
+          </>
+        ) : (
+          <>
+            <label className="control-label">{t('SINGLE:MSG_TEMPLATEINSTANCES_CREATEFORM_DIV13_1')}</label>
+            <div className="help-block">{t('SINGLE:MSG_TEMPLATEINSTANCES_CREATEFORM_DIV16_1')}</div>
+          </>
+        )
+      ) : null}
     </>
   );
 };

--- a/frontend/public/components/hypercloud/service-binding.tsx
+++ b/frontend/public/components/hypercloud/service-binding.tsx
@@ -22,7 +22,7 @@ const ServiceBindingDetails: React.FC<ServiceBindingDetailsProps> = ({ obj: serv
         <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(serviceBinding, t) })} />
         <div className="row">
           <div className="col-md-6">
-            <ResourceSummary resource={serviceBinding} showOwner={false}></ResourceSummary>
+            <ResourceSummary resource={serviceBinding} showOwner={false} showAnnotations={false}></ResourceSummary>
           </div>
           <div className="col-md-6">
             <dl className="co-m-pane__details">

--- a/frontend/public/components/hypercloud/service-broker.tsx
+++ b/frontend/public/components/hypercloud/service-broker.tsx
@@ -50,7 +50,7 @@ const { details, editResource } = navFactory;
 const ServiceBrokersDetailsPage: React.FC<ServiceBrokersDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={serviceBrokerMenuActions} pages={[details(ServiceBrokerDetails), editResource()]} />;
 ServiceBrokersDetailsPage.displayName = 'ServiceBrokersDetailsPage';
 
-const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-lg'), classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'), classNames('pf-m-hidden', 'pf-m-visible-on-xl'), Kebab.columnClass];
+const tableColumnClasses = ['', classNames('pf-m-hidden', 'pf-m-visible-on-sm'), classNames('pf-m-hidden', 'pf-m-visible-on-sm'), classNames('pf-m-hidden', 'pf-m-visible-on-lg'), classNames('pf-m-hidden', 'pf-m-visible-on-lg'), Kebab.columnClass];
 
 const ServiceBrokerPhase = instance => {
   let phase = '';
@@ -81,6 +81,7 @@ const ServiceBrokerTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, 
       <TableData className={tableColumnClasses[2]}>
         <Status status={phase} />
       </TableData>
+      <TableData className={tableColumnClasses[3]}>{obj.spec?.url}</TableData>
       <TableData className={tableColumnClasses[4]}>
         <Timestamp timestamp={obj.metadata.creationTimestamp} />
       </TableData>
@@ -110,6 +111,12 @@ const ServiceBrokerTableHeader = (t?: TFunction) => {
       sortFunc: 'ServiceBrokerPhase',
       transforms: [sortable],
       props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: t('COMMON:MSG_MAIN_TABLEHEADER_4'),
+      sortField: 'spec.url',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[3] },
     },
     {
       title: t('COMMON:MSG_MAIN_TABLEHEADER_12'),

--- a/frontend/public/components/hypercloud/service-class.tsx
+++ b/frontend/public/components/hypercloud/service-class.tsx
@@ -30,7 +30,9 @@ const ServiceClassDetails: React.FC<ServiceClassDetailsProps> = ({ obj: serviceC
               <dt>{t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_17')}</dt>
               <dd>{serviceClass.spec?.externalName}</dd>
               <dt>{t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_18')}</dt>
-              <dd>{serviceClass.spec?.serviceBrokerName}</dd>
+              <dd>
+                <ResourceLink kind="ServiceBroker" name={serviceClass.spec?.serviceBrokerName} title={serviceClass.spec?.serviceBrokerName} namespace={serviceClass.metadata.namespace} />
+              </dd>
             </dl>
           </div>
         </div>

--- a/frontend/public/components/hypercloud/service-instance.tsx
+++ b/frontend/public/components/hypercloud/service-instance.tsx
@@ -106,6 +106,7 @@ const ServiceInstanceDetails: React.FC<ServiceInstanceDetailsProps> = props => {
           samples={[]}
           isCreateMode={true}
           showDetails={true}
+          noTabsOnlyDetails={true}
         />
       </div>
     </>
@@ -118,7 +119,7 @@ type ServiceInstanceDetailsProps = {
 };
 
 const { details, editYaml } = navFactory;
-const ServiceInstancesDetailsPage: React.FC<ServiceInstancesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={serviceInstanceMenuActions} pages={[details(ServiceInstanceDetails), editYaml()]} />;
+const ServiceInstancesDetailsPage: React.FC<ServiceInstancesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={serviceInstanceMenuActions} getResourceStatus={serviceInstanceStatusReducer} pages={[details(ServiceInstanceDetails), editYaml()]} />;
 ServiceInstancesDetailsPage.displayName = 'ServiceInstancesDetailsPage';
 
 const tableColumnClasses = [

--- a/frontend/public/components/hypercloud/service-plan.tsx
+++ b/frontend/public/components/hypercloud/service-plan.tsx
@@ -10,7 +10,7 @@ import { K8sResourceKind, modelFor } from '../../module/k8s';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
 import { DetailsPage, ListPage, Table, TableData, TableRow } from '../factory';
-import { navFactory, SectionHeading, ResourceSummary, ResourceLink, Timestamp } from '../utils';
+import { navFactory, SectionHeading, ResourceSummary, ResourceLink, Timestamp, ResourceIcon } from '../utils';
 import { ResourceSidebar } from '../sidebars/resource-sidebar';
 const kind = ServicePlanModel.kind;
 
@@ -98,18 +98,21 @@ const ServicePlanTableRow = (setSidebarDetails, setShowSidebar, setSidebarTitle,
   const { obj, index, key, style } = props;
   const SidebarLink = ({ name, kind, obj }) => {
     return (
-      <Button
-        type="button"
-        variant="link"
-        isInline
-        onClick={() => {
-          setShowSidebar(true);
-          setSidebarDetails(obj);
-          setSidebarTitle(obj.spec?.externalName);
-        }}
-      >
-        {name}
-      </Button>
+      <span className="co-resource-item">
+        <ResourceIcon kind={kind} />
+        <Button
+          type="button"
+          variant="link"
+          isInline
+          onClick={() => {
+            setShowSidebar(true);
+            setSidebarDetails(obj);
+            setSidebarTitle(obj.spec?.externalName);
+          }}
+        >
+          {name}
+        </Button>
+      </span>
     );
   };
   return (
@@ -158,6 +161,7 @@ const ServicePlansPage: React.FC<ServicePlansPageProps> = props => {
           showID={false}
           showPodSelector={false}
           showNodeSelector={false}
+          showDescription={true}
           showOwner={false}
           showAnnotations={false}
           showSidebar={showSidebar}

--- a/frontend/public/components/hypercloud/template-instance.tsx
+++ b/frontend/public/components/hypercloud/template-instance.tsx
@@ -64,7 +64,7 @@ const TemplateInstanceDetails: React.FC<TemplateInstanceDetailsProps> = ({ obj: 
         <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(templateInstance, t) })} />
         <div className="row">
           <div className="col-md-6">
-            <ResourceSummary resource={templateInstance} showOwner={false}></ResourceSummary>
+            <ResourceSummary resource={templateInstance} showOwner={false} showPodSelector showNodeSelector></ResourceSummary>
           </div>
           <div className="col-md-6">
             <dl className="co-m-pane__details">
@@ -89,7 +89,7 @@ type TemplateInstanceDetailsProps = {
 };
 
 const { details, editYaml } = navFactory;
-const TemplateInstancesDetailsPage: React.FC<TemplateInstancesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={templateInstanceMenuActions} pages={[details(TemplateInstanceDetails), editYaml()]} />;
+const TemplateInstancesDetailsPage: React.FC<TemplateInstancesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} getResourceStatus={templateInstancePhase} menuActions={templateInstanceMenuActions} pages={[details(TemplateInstanceDetails), editYaml()]} />;
 TemplateInstancesDetailsPage.displayName = 'TemplateInstancesDetailsPage';
 
 const tableColumnClasses = [


### PR DESCRIPTION
- ServiceClass디테일의 ServiceBroker항목 링크 제공, ServicePlan리스트 이름 앞에 리소스아이콘 추가
- ServiceClass디테일의 ServicePlan탭 사이드패널에 description 추가
- ClusterServiceBroker 디테일 상단에 status 표시 추가 및 Annotation항목 제거
- ServiceBroker와 ClusterServiceBroker 리스트페이지에 URL항목 추가
- ServiceInstance 디테일 상단에 status 표시
- ServiceBinding디테일 Annotation 항목 제거
- TemplateInstance 생성페이지 '템플릿 파라미터' 텍스트 추가
- ClusterTemplateClaim리스트페이지 status필터추가, 디테일페이지 status항목 아이콘도 표시되도록 수정