### PR TITLE
[feat][patch] 네임스페이스의 롤 바인딩 탭 화면에서 생성 버튼이 좌측에 위치하도록 수정

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -225,8 +225,8 @@ const rowFilters = t => {
   ];
 };
 
-export const RoleBindingsPage = ({ namespace = undefined, showTitle = true, mock = false, staticFilters = undefined, createPath = '/k8s/cluster/rolebindings/~new', single = false }) => {
-  const { t } = useTranslation(); 
+export const RoleBindingsPage = ({ namespace = undefined, showTitle = true, mock = false, staticFilters = undefined, createPath = '/k8s/cluster/rolebindings/~new', single = false, displayTitleRow = true }) => {
+  const { t } = useTranslation();
 
   const pages = [
     {
@@ -273,6 +273,7 @@ export const RoleBindingsPage = ({ namespace = undefined, showTitle = true, mock
         rowFilters={staticFilters ? [] : rowFilters.bind(null, t)()}
         staticFilters={staticFilters}
         showTitle={showTitle}
+        displayTitleRow={displayTitleRow}
         textFilter="role-binding"
         title={t('COMMON:MSG_LNB_MENU_76')}
         isClusterScope
@@ -299,6 +300,7 @@ export const RoleBindingsPage = ({ namespace = undefined, showTitle = true, mock
       rowFilters={staticFilters ? [] : rowFilters.bind(null, t)()}
       staticFilters={staticFilters}
       showTitle={showTitle}
+      displayTitleRow={displayTitleRow}
       textFilter="role-binding"
       title={t('COMMON:MSG_LNB_MENU_76')}
       isClusterScope

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -143,7 +143,7 @@ export const FireMan_ = connect(null, { filterList })(
     };
 
     render() {
-      const { canCreate, createAccessReview, createButtonText, createProps = {}, helpText, resources, badge, title, unclickableMsg, multiNavPages, baseURL, basePath } = this.props;
+      const { canCreate, createAccessReview, createButtonText, createProps = {}, helpText, resources, badge, title, displayTitleRow, unclickableMsg, multiNavPages, baseURL, basePath } = this.props;
 
       let createLink;
       if (canCreate) {
@@ -198,12 +198,14 @@ export const FireMan_ = connect(null, { filterList })(
         </div>
       );
 
+      const titleClassName = displayTitleRow ? 'co-m-nav-title--row' : 'co-m-nav-title--column';
+
       return (
         <>
           {/* Badge rendered from PageHeading only when title is present */}
 
-          <PageHeading title={title} badge={title ? badge : null} className={classNames({ 'co-m-nav-title--row': createLink })}>
-            {multiNavPages ? undefined : buttonComponent}
+          <PageHeading title={title} badge={title ? badge : null} className={classNames({ [titleClassName]: createLink })}>
+            {multiNavPages ? undefined : <div style={{ marginBottom: displayTitleRow ? 0 : '10px' }}>{buttonComponent}</div>}
             {!title && badge && <div>{badge}</div>}
           </PageHeading>
 
@@ -260,11 +262,12 @@ FireMan_.propTypes = {
   selectorFilterLabel: PropTypes.string,
   textFilter: PropTypes.string,
   title: PropTypes.string,
+  displayTitleRow: PropTypes.bool,
 };
 
-/** @type {React.SFC<{ListComponent: React.ComponentType<any>, kind: string, helpText?: any, namespace?: string, filterLabel?: string, textFilter?: string, title?: string, showTitle?: boolean, rowFilters?: any[], selector?: any, fieldSelector?: string, canCreate?: boolean, createButtonText?: string, createProps?: any, mock?: boolean, badge?: React.ReactNode, createHandler?: any, hideToolbar?: boolean, hideLabelFilter?: boolean, customData?: any, setSidebarDetails?:any, setShowSidebar?:any, setSidebarTitle?: any, multiNavPages?: any, isClusterScope?: boolean, defaultSelectedRows?: string[]} >} */
+/** @type {React.SFC<{ListComponent: React.ComponentType<any>, kind: string, helpText?: any, namespace?: string, filterLabel?: string, textFilter?: string, title?: string, showTitle?: boolean, displayTitleRow?: boolean, rowFilters?: any[], selector?: any, fieldSelector?: string, canCreate?: boolean, createButtonText?: string, createProps?: any, mock?: boolean, badge?: React.ReactNode, createHandler?: any, hideToolbar?: boolean, hideLabelFilter?: boolean, customData?: any, setSidebarDetails?:any, setShowSidebar?:any, setSidebarTitle?: any, multiNavPages?: any, isClusterScope?: boolean, defaultSelectedRows?: string[]} >} */
 export const ListPage = withFallback(props => {
-  const { autoFocus, canCreate, createButtonText, createHandler, customData, fieldSelector, filterLabel, filters, helpText, kind, limit, ListComponent, mock, name, nameFilter, namespace, selector, showTitle = true, skipAccessReview, textFilter, match, badge, hideToolbar, hideLabelFilter, setSidebarDetails, setShowSidebar, setSidebarTitle, multiNavPages, isClusterScope, defaultSelectedRows } = props;
+  const { autoFocus, canCreate, createButtonText, createHandler, customData, fieldSelector, filterLabel, filters, helpText, kind, limit, ListComponent, mock, name, nameFilter, namespace, selector, showTitle = true, displayTitleRow, skipAccessReview, textFilter, match, badge, hideToolbar, hideLabelFilter, setSidebarDetails, setShowSidebar, setSidebarTitle, multiNavPages, isClusterScope, defaultSelectedRows } = props;
   let { createProps } = props;
   const { t } = useTranslation();
   const ko = kindObj(kind);
@@ -349,6 +352,7 @@ export const ListPage = withFallback(props => {
       rowFilters={rowFilters}
       selectorFilterLabel="Filter by selector (app=nginx) ..."
       showTitle={showTitle}
+      displayTitleRow={displayTitleRow}
       textFilter={textFilter}
       title={title}
       badge={badge}
@@ -364,9 +368,9 @@ export const ListPage = withFallback(props => {
 
 ListPage.displayName = 'ListPage';
 
-/** @type {React.SFC<{canCreate?: boolean, createButtonText?: string, createProps?: any, createAccessReview?: Object, flatten?: Function, title?: string, label?: string, hideTextFilter?: boolean, showTitle?: boolean, helpText?: any, filterLabel?: string, textFilter?: string, rowFilters?: any[], resources: any[], ListComponent: React.ComponentType<any>, namespace?: string, customData?: any, badge?: React.ReactNode, hideToolbar?: boolean, hideLabelFilter?: boolean setSidebarDetails?:any setShowSidebar?:any setSidebarTitle?: any, multiNavPages?: any, multiNavBaseURL?: string, isClusterScope?: boolean, defaultSelectedRows?: string[]} >} */
+/** @type {React.SFC<{canCreate?: boolean, createButtonText?: string, createProps?: any, createAccessReview?: Object, flatten?: Function, title?: string, label?: string, hideTextFilter?: boolean, showTitle?: boolean, displayTitleRow?: boolean, helpText?: any, filterLabel?: string, textFilter?: string, rowFilters?: any[], resources: any[], ListComponent: React.ComponentType<any>, namespace?: string, customData?: any, badge?: React.ReactNode, hideToolbar?: boolean, hideLabelFilter?: boolean setSidebarDetails?:any setShowSidebar?:any setSidebarTitle?: any, multiNavPages?: any, multiNavBaseURL?: string, isClusterScope?: boolean, defaultSelectedRows?: string[]} >} */
 export const MultiListPage = props => {
-  const { autoFocus, canCreate, createAccessReview, createButtonText, createProps, filterLabel, flatten, helpText, label, ListComponent, setSidebarDetails, setShowSidebar, setSidebarTitle, mock, namespace, rowFilters, showTitle = true, staticFilters, textFilter, title, customData, badge, hideToolbar, hideLabelFilter, multiNavPages, multiNavBaseURL, isClusterScope, defaultSelectedRows } = props;
+  const { autoFocus, canCreate, createAccessReview, createButtonText, createProps, filterLabel, flatten, helpText, label, ListComponent, setSidebarDetails, setShowSidebar, setSidebarTitle, mock, namespace, rowFilters, showTitle = true, displayTitleRow = true, staticFilters, textFilter, title, customData, badge, hideToolbar, hideLabelFilter, multiNavPages, multiNavBaseURL, isClusterScope, defaultSelectedRows } = props;
 
   const { t } = useTranslation();
 
@@ -381,7 +385,7 @@ export const MultiListPage = props => {
   }));
 
   return (
-    <FireMan_ autoFocus={autoFocus} canCreate={canCreate} createAccessReview={createAccessReview} createButtonText={createButtonText || 'Create'} createProps={createProps} filterLabel={filterLabel || 'by name'} helpText={helpText} resources={mock ? [] : resources} selectorFilterLabel="Filter by selector (app=nginx) ..." textFilter={textFilter} title={showTitle ? title : undefined} badge={badge} unclickableMsg={unclickableMsg} multiNavPages={multiNavPages} baseURL={multiNavBaseURL}>
+    <FireMan_ autoFocus={autoFocus} canCreate={canCreate} createAccessReview={createAccessReview} createButtonText={createButtonText || 'Create'} createProps={createProps} filterLabel={filterLabel || 'by name'} helpText={helpText} resources={mock ? [] : resources} selectorFilterLabel="Filter by selector (app=nginx) ..." textFilter={textFilter} title={showTitle ? title : undefined} displayTitleRow={displayTitleRow} badge={badge} unclickableMsg={unclickableMsg} multiNavPages={multiNavPages} baseURL={multiNavBaseURL}>
       <Firehose resources={mock ? [] : resources}>
         <ListPageWrapper_ flatten={flatten} kinds={_.map(resources, 'kind')} label={label} ListComponent={ListComponent} setSidebarDetails={setSidebarDetails} setShowSidebar={setShowSidebar} setSidebarTitle={setSidebarTitle} textFilter={textFilter} rowFilters={rowFilters} staticFilters={staticFilters} customData={customData} hideToolbar={hideToolbar} hideLabelFilter={hideLabelFilter} defaultSelectedRows={defaultSelectedRows} />
       </Firehose>

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -179,8 +179,8 @@ export const NamespacesPage = props => {
       ListComponent={NamespacesList}
       canCreate={true}
       multiNavPages={pages}
-      // createProps={createProps}
-      // createHandler={() => createNamespaceModal({ blocking: true })}
+    // createProps={createProps}
+    // createHandler={() => createNamespaceModal({ blocking: true })}
     />
   );
 };
@@ -226,19 +226,19 @@ const projectTableHeader = ({ showMetrics, showActions }) => {
     },
     ...(showMetrics
       ? [
-          {
-            title: 'Memory',
-            sortFunc: 'namespaceMemory',
-            transforms: [sortable],
-            props: { className: projectColumnClasses[4] },
-          },
-          {
-            title: 'CPU',
-            sortFunc: 'namespaceCPU',
-            transforms: [sortable],
-            props: { className: projectColumnClasses[5] },
-          },
-        ]
+        {
+          title: 'Memory',
+          sortFunc: 'namespaceMemory',
+          transforms: [sortable],
+          props: { className: projectColumnClasses[4] },
+        },
+        {
+          title: 'CPU',
+          sortFunc: 'namespaceCPU',
+          transforms: [sortable],
+          props: { className: projectColumnClasses[5] },
+        },
+      ]
       : []),
     {
       title: 'Created',
@@ -494,8 +494,8 @@ const DetailsStateToProps = ({ UI }) => ({
 export const NamespaceDetails = connect(DetailsStateToProps)(NamespaceDetails_);
 
 const RolesPage = ({ obj: { metadata } }) => {
-  const rolebindingspage = <RoleBindingsPage createPath={`/k8s/ns/${metadata.name}/rolebindings/~new?rolekind=Role`} namespace={metadata.name} showTitle={true} single={true} />;
-  const rolebindingclaimspage = <RoleBindingClaimsPage createPath={`/k8s/ns/${metadata.name}/rolebindings/~new?rolekind=Role`} namespace={metadata.name} showTitle={true} single={true} />;
+  const rolebindingspage = <RoleBindingsPage createPath={`/k8s/ns/${metadata.name}/rolebindings/~new?rolekind=Role`} namespace={metadata.name} showTitle={true} single={true} displayTitleRow={false} />;
+  const rolebindingclaimspage = <RoleBindingClaimsPage createPath={`/k8s/ns/${metadata.name}/rolebindings/~new?rolekind=Role`} namespace={metadata.name} showTitle={true} single={true} displayTitleRow={false} />;
   return (
     <>
       <div className={classNames('namespace-details_role-binding')}>{rolebindingspage}</div>
@@ -561,11 +561,11 @@ class NamespaceBarDropdowns_ extends React.Component {
     }
     const defaultActionItem = canCreateProject
       ? [
-          {
-            actionTitle: `Create ${model.label}`,
-            actionKey: CREATE_NEW_RESOURCE,
-          },
-        ]
+        {
+          actionTitle: `Create ${model.label}`,
+          actionKey: CREATE_NEW_RESOURCE,
+        },
+      ]
       : [];
 
     const onChange = newNamespace => {


### PR DESCRIPTION
기획에 따라 버튼 위치를 수정했습니다.

![image](https://user-images.githubusercontent.com/29051383/124900998-947f2a00-e01c-11eb-85e4-f71b5d3e270a.png)

타이틀과 버튼이 같이 존재할 때는 버튼의 위치가 항상 우측에 위치해 있어서, 타이틀과 버튼이 같이 있을 때도 좌측에 나란히 있을 수 있도록 `list-page.jsx`의 공통 컴포넌트에 `displayTitleRow` props를 추가하였습니다.