### PR TITLE
[refactor] 소유자 정보 가져오는 default path값 metadata.annotations.creator로 수정

### DIFF
--- a/frontend/public/components/hypercloud/cluster-service-broker.tsx
+++ b/frontend/public/components/hypercloud/cluster-service-broker.tsx
@@ -23,7 +23,7 @@ const ClusterServiceBrokerDetails: React.FC<ClusterServiceBrokerDetailsProps> = 
         <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(clusterServiceBroker, t) })} />
         <div className="row">
           <div className="col-md-6">
-            <ResourceSummary resource={clusterServiceBroker} showOwner={false} showAnnotations={false}></ResourceSummary>
+            <ResourceSummary resource={clusterServiceBroker} showAnnotations={false}></ResourceSummary>
           </div>
           <div className="col-md-6">
             <dl className="co-m-pane__details">

--- a/frontend/public/components/hypercloud/cluster-service-class.tsx
+++ b/frontend/public/components/hypercloud/cluster-service-class.tsx
@@ -21,7 +21,7 @@ const ClusterServiceClassDetails: React.FC<ClusterServiceClassDetailsProps> = ({
         <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(clusterServiceClass, t) })} />
         <div className="row">
           <div className="col-md-6">
-            <ResourceSummary resource={clusterServiceClass} showPodSelector={false} showNodeSelector={false} showAnnotations={false} showOwner={false}></ResourceSummary>
+            <ResourceSummary resource={clusterServiceClass} showPodSelector={false} showNodeSelector={false} showAnnotations={false}></ResourceSummary>
           </div>
           <div className="col-md-6">
             <dl className="co-m-pane__details">

--- a/frontend/public/components/hypercloud/cluster-template.tsx
+++ b/frontend/public/components/hypercloud/cluster-template.tsx
@@ -47,7 +47,7 @@ const ClusterTemplateDetails: React.FC<ClusterTemplateDetailsProps> = ({ obj: cl
         <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(clusterTemplate, t) })} />
         <div className="row">
           <div className="col-md-6">
-            <ResourceSummary resource={clusterTemplate} showOwner={false}></ResourceSummary>
+            <ResourceSummary resource={clusterTemplate}></ResourceSummary>
           </div>
           <div className="col-md-6">
             <dl className="co-m-pane__details">

--- a/frontend/public/components/hypercloud/service-binding.tsx
+++ b/frontend/public/components/hypercloud/service-binding.tsx
@@ -22,7 +22,7 @@ const ServiceBindingDetails: React.FC<ServiceBindingDetailsProps> = ({ obj: serv
         <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(serviceBinding, t) })} />
         <div className="row">
           <div className="col-md-6">
-            <ResourceSummary resource={serviceBinding} showOwner={false} showAnnotations={false}></ResourceSummary>
+            <ResourceSummary resource={serviceBinding} showAnnotations={false}></ResourceSummary>
           </div>
           <div className="col-md-6">
             <dl className="co-m-pane__details">

--- a/frontend/public/components/hypercloud/service-broker.tsx
+++ b/frontend/public/components/hypercloud/service-broker.tsx
@@ -25,7 +25,7 @@ const ServiceBrokerDetails: React.FC<ServiceBrokerDetailsProps> = ({ obj: servic
         <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(serviceBroker, t) })} />
         <div className="row">
           <div className="col-md-6">
-            <ResourceSummary resource={serviceBroker} showAnnotations={false} showOwner={false}></ResourceSummary>
+            <ResourceSummary resource={serviceBroker} showAnnotations={false}></ResourceSummary>
           </div>
           <div className="col-md-6">
             <dl className="co-m-pane__details">

--- a/frontend/public/components/hypercloud/service-class.tsx
+++ b/frontend/public/components/hypercloud/service-class.tsx
@@ -21,7 +21,7 @@ const ServiceClassDetails: React.FC<ServiceClassDetailsProps> = ({ obj: serviceC
         <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(serviceClass, t) })} />
         <div className="row">
           <div className="col-md-6">
-            <ResourceSummary resource={serviceClass} showPodSelector={false} showNodeSelector={false} showAnnotations={false} showOwner={false}></ResourceSummary>
+            <ResourceSummary resource={serviceClass} showPodSelector={false} showNodeSelector={false} showAnnotations={false}></ResourceSummary>
           </div>
           <div className="col-md-6">
             <dl className="co-m-pane__details">

--- a/frontend/public/components/hypercloud/service-instance.tsx
+++ b/frontend/public/components/hypercloud/service-instance.tsx
@@ -68,7 +68,7 @@ const ServiceInstanceDetails: React.FC<ServiceInstanceDetailsProps> = props => {
           <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(serviceInstance, t) })} />
           <div className="row">
             <div className="col-md-6">
-              <ResourceSummary resource={serviceInstance} showOwner={false}></ResourceSummary>
+              <ResourceSummary resource={serviceInstance}></ResourceSummary>
             </div>
             <div className="col-md-6">
               <dl className="co-m-pane__details">

--- a/frontend/public/components/hypercloud/template-instance.tsx
+++ b/frontend/public/components/hypercloud/template-instance.tsx
@@ -64,7 +64,7 @@ const TemplateInstanceDetails: React.FC<TemplateInstanceDetailsProps> = ({ obj: 
         <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(templateInstance, t) })} />
         <div className="row">
           <div className="col-md-6">
-            <ResourceSummary resource={templateInstance} showOwner={false} showPodSelector showNodeSelector></ResourceSummary>
+            <ResourceSummary resource={templateInstance} showPodSelector showNodeSelector></ResourceSummary>
           </div>
           <div className="col-md-6">
             <dl className="co-m-pane__details">

--- a/frontend/public/components/hypercloud/template.tsx
+++ b/frontend/public/components/hypercloud/template.tsx
@@ -48,7 +48,7 @@ const TemplateDetails: React.FC<TemplateDetailsProps> = ({ obj: template }) => {
         <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(template, t) })} />
         <div className="row">
           <div className="col-md-6">
-            <ResourceSummary resource={template} showOwner={false}></ResourceSummary>
+            <ResourceSummary resource={template}></ResourceSummary>
           </div>
           <div className="col-md-6">
             <dl className="co-m-pane__details">

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -40,7 +40,7 @@ const getDescriptionStringKey = (obj: K8sResourceKind): string => {
   }
 };
 
-export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({ children, resource, customPathName, customPathId, showName = true, showOwner = true, showID = false, showDescription = false, showPodSelector = false, showNodeSelector = false, showAnnotations = true, showTolerations = false, podSelector = 'spec.selector', nodeSelector = 'spec.template.spec.nodeSelector' }) => {
+export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({ children, resource, customPathName, customPathId, showName = true, showOwner = true, useHcOwnerPath = true, showID = false, showDescription = false, showPodSelector = false, showNodeSelector = false, showAnnotations = true, showTolerations = false, podSelector = 'spec.selector', nodeSelector = 'spec.template.spec.nodeSelector' }) => {
   const { metadata, type } = resource;
   const reference = referenceFor(resource);
   const model = modelFor(reference);
@@ -112,7 +112,7 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({ children, res
           </DetailsItem>
           {showOwner && (
             <DetailsItem label={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_44')} obj={resource} path="metadata.ownerReferences">
-              <OwnerReferences resource={resource} />
+              <OwnerReferences resource={resource} useHcOwnerPath={useHcOwnerPath} />
             </DetailsItem>
           )}
         </dl>
@@ -147,6 +147,7 @@ export type ResourceSummaryProps = {
   children?: React.ReactNode;
   customPathName?: string;
   customPathId?: string;
+  useHcOwnerPath?: boolean;
 };
 
 export type ResourcePodCountProps = {

--- a/frontend/public/components/utils/owner-references.tsx
+++ b/frontend/public/components/utils/owner-references.tsx
@@ -3,20 +3,21 @@ import * as _ from 'lodash-es';
 import { K8sResourceKind, OwnerReference, referenceForOwnerRef } from '../../module/k8s';
 import { ResourceLink } from './resource-link';
 
-export const OwnerReferences: React.FC<OwnerReferencesProps> = ({ resource }) => {
-  const owners = (_.get(resource.metadata, 'ownerReferences') || []).map((o: OwnerReference) => (
-    <ResourceLink
-      key={o.uid}
-      kind={referenceForOwnerRef(o)}
-      name={o.name}
-      namespace={resource.metadata.namespace}
-    />
-  ));
-  return owners.length ? <>{owners}</> : <span className="text-muted">No owner</span>;
+export const OwnerReferences: React.FC<OwnerReferencesProps> = ({ resource, useHcOwnerPath }) => {
+  if (useHcOwnerPath) {
+    // MEMO : HyperCloud에선 owner의 기본 path가 annotation.creator 이다.
+    const owner = _.get(resource.metadata, 'annotations.creator');
+    return !!owner ? <span>{owner}</span> : <span className="text-muted">No owner</span>;
+  } else {
+    // MEMO : 기존 Openshift에서 owner가져오는 방식.
+    const owners = (_.get(resource.metadata, 'ownerReferences') || []).map((o: OwnerReference) => <ResourceLink key={o.uid} kind={referenceForOwnerRef(o)} name={o.name} namespace={resource.metadata.namespace} />);
+    return owners.length ? <>{owners}</> : <span className="text-muted">No owner</span>;
+  }
 };
 
 type OwnerReferencesProps = {
   resource: K8sResourceKind;
+  useHcOwnerPath?: boolean;
 };
 
 OwnerReferences.displayName = 'OwnerReferences';

--- a/frontend/public/components/utils/owner-references.tsx
+++ b/frontend/public/components/utils/owner-references.tsx
@@ -2,16 +2,18 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { K8sResourceKind, OwnerReference, referenceForOwnerRef } from '../../module/k8s';
 import { ResourceLink } from './resource-link';
+import { useTranslation } from 'react-i18next';
 
 export const OwnerReferences: React.FC<OwnerReferencesProps> = ({ resource, useHcOwnerPath }) => {
+  const { t } = useTranslation();
   if (useHcOwnerPath) {
     // MEMO : HyperCloud에선 owner의 기본 path가 annotation.creator 이다.
     const owner = _.get(resource.metadata, 'annotations.creator');
-    return !!owner ? <span>{owner}</span> : <span className="text-muted">No owner</span>;
+    return !!owner ? <span>{owner}</span> : <span className="text-muted">{t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_97')}</span>;
   } else {
     // MEMO : 기존 Openshift에서 owner가져오는 방식.
     const owners = (_.get(resource.metadata, 'ownerReferences') || []).map((o: OwnerReference) => <ResourceLink key={o.uid} kind={referenceForOwnerRef(o)} name={o.name} namespace={resource.metadata.namespace} />);
-    return owners.length ? <>{owners}</> : <span className="text-muted">No owner</span>;
+    return owners.length ? <>{owners}</> : <span className="text-muted">{t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_97')}</span>;
   }
 };
 


### PR DESCRIPTION
* HyperCloud에선 owner 정보를 가져오는 기본 path가 'metadata.annotations.creator' 로 정해져서 모든 디테일 페이지의 owner항목 기본path를 변경함.
* 기존 openshift에서 구현한 owner reference를 사용하고 싶을 땐 ResourceSummary props로 useHcOwnerPath={false}를 넣어주면 됨.