### PR TITLE
265857 롤바인딩클레임 생성 후 에러화면 조회, 264265 파이프라인 리소스 생성 화면에 description 추가 요청, add status for helm

### DIFF
--- a/frontend/packages/console-shared/src/components/status/Status.tsx
+++ b/frontend/packages/console-shared/src/components/status/Status.tsx
@@ -6,7 +6,6 @@ import StatusIconAndText from './StatusIconAndText';
 import { ErrorStatus, InfoStatus, ProgressStatus, SuccessStatus } from './statuses';
 import { StatusComponentProps } from './types';
 import * as DeletedIcon from '@console/internal/imgs/hypercloud/delete.svg';
-import { TestIcon } from './icons';
 
 export const Status: React.FC<StatusProps> = ({ status, title, children, iconOnly, noTooltip, className }) => {
   const statusProps = { title: title || status, iconOnly, noTooltip, className };
@@ -124,7 +123,7 @@ export const Status: React.FC<StatusProps> = ({ status, title, children, iconOnl
       return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
     case 'Unready':
     case 'UnReady':
-      return <StatusIconAndText {...statusProps} icon={<TestIcon />} />;
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
   
     default:
       return <>{status || DASH}</>;

--- a/frontend/packages/console-shared/src/components/status/Status.tsx
+++ b/frontend/packages/console-shared/src/components/status/Status.tsx
@@ -5,6 +5,7 @@ import { YellowExclamationTriangleIcon } from './icons';
 import StatusIconAndText from './StatusIconAndText';
 import { ErrorStatus, InfoStatus, ProgressStatus, SuccessStatus } from './statuses';
 import { StatusComponentProps } from './types';
+import { TestIcon } from './icons';
 
 export const Status: React.FC<StatusProps> = ({ status, title, children, iconOnly, noTooltip, className }) => {
   const statusProps = { title: title || status, iconOnly, noTooltip, className };
@@ -63,6 +64,7 @@ export const Status: React.FC<StatusProps> = ({ status, title, children, iconOnl
     case 'Lost':
     case 'Rejected':
     case 'UpgradeFailed':
+    case 'Failure':
       return <ErrorStatus {...statusProps}>{children}</ErrorStatus>;
 
     case 'Accepted':
@@ -87,6 +89,38 @@ export const Status: React.FC<StatusProps> = ({ status, title, children, iconOnl
     case 'Unknown':
       return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
 
+    case 'ChartFetched':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
+    case 'ChartFetchFailed':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
+    case 'Installing':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
+    case 'Upgrading':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
+    case 'Deployed':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
+    case 'DeployFailed':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
+    case 'Testing':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
+    case 'TestFailed':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
+    case 'Tested':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;    
+    case 'RollingBack':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
+    case 'RolledBack':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
+    case 'RollBackFailed':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
+    case 'Applied':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
+    case 'Destroyed':
+      return <StatusIconAndText {...statusProps} icon={<UnknownIcon />} />;
+    case 'Unready':
+    case 'UnReady':
+      return <StatusIconAndText {...statusProps} icon={<TestIcon />} />;
+  
     default:
       return <>{status || DASH}</>;
   }

--- a/frontend/public/components/hypercloud/form/pipelineresources/create-pipelineresource.tsx
+++ b/frontend/public/components/hypercloud/form/pipelineresources/create-pipelineresource.tsx
@@ -61,19 +61,26 @@ const CreatePipelineResourceComponent: React.FC<PipelineResourceFormProps> = pro
         <Controller name="metadata.labels" id="label" labelClassName="co-text-sample" as={SelectorInput} control={control} tags={[]} />
       </Section>
 
-      <Section label={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_4')} id="type">
+      <Section label={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_4')} id="type" description={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_10')}>
         <Dropdown name="spec.type" items={typeList} defaultValue={defaultValues.spec.type} />
       </Section>
 
       {type === 'git' && (
-        <Section label={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_5')} id="revision">
+        <Section label={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_5')} id="revision" description={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_11')}>
           <TextInput inputClassName="pf-c-form-control" id="spec.revision" name="spec.revision" defaultValue={defaultRevision} />
+        </Section>        
+      )}
+      {type === 'git' && (
+        <Section label={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_6')} id="url" description={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_12')}>
+          <TextInput inputClassName="pf-c-form-control" id="spec.url" name="spec.url" defaultValue={defaultUrl} />
         </Section>
       )}
 
-      <Section label={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_6')} id="url">
-        <TextInput inputClassName="pf-c-form-control" id="spec.url" name="spec.url" defaultValue={defaultUrl} />
-      </Section>
+      {type === 'image' && (
+        <Section label={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_6')} id="url" description='참조할 이미지 주소 또는 이미지가 저장될 주소'>
+          <TextInput inputClassName="pf-c-form-control" id="spec.url" name="spec.url" defaultValue={defaultUrl} />
+        </Section>
+      )}
     </>
   );
 };

--- a/frontend/public/components/hypercloud/role-binding-claim.tsx
+++ b/frontend/public/components/hypercloud/role-binding-claim.tsx
@@ -224,7 +224,7 @@ export const RoleBindingClaimDetailsList: React.FC<RoleBindingClaimDetailsListPr
   return (
     <dl className="co-m-pane__details">
       <DetailsItem label={`${t('COMMON:MSG_MAIN_TABLEHEADER_98')}`} obj={resource} path="resourceName">
-        {resource.status.url}
+        {resource?.resourceName}
       </DetailsItem>
       <DetailsItem label={`${t('COMMON:MSG_COMMON_TABLEHEADER_2')}`} obj={resource} path="status.status">
         <Status status={resource.status.status} />

--- a/frontend/public/components/hypercloud/role-binding-claim.tsx
+++ b/frontend/public/components/hypercloud/role-binding-claim.tsx
@@ -227,11 +227,11 @@ export const RoleBindingClaimDetailsList: React.FC<RoleBindingClaimDetailsListPr
         {resource?.resourceName}
       </DetailsItem>
       <DetailsItem label={`${t('COMMON:MSG_COMMON_TABLEHEADER_2')}`} obj={resource} path="status.status">
-        <Status status={resource.status.status} />
+        <Status status={resource.status?.status} />
       </DetailsItem>
       {resource.status?.status === 'Rejected' &&
         <DetailsItem label={`${t('COMMON:MSG_DETAILS_TABDETAILS_20')}`} obj={resource} path="spec.reason">
-          {resource.status.reason}
+          {resource.status?.reason}
         </DetailsItem>
       }
     </dl>


### PR DESCRIPTION
[bugfix][patch][IMS]265857 롤바인딩클레임 생성 후 에러화면 조회
[원인] 존재하지 않는 {resource.status.url} 참조
[해결] 보여줘야할 resourceName으로 변경

[bugfix][patch][IMS]264265 파이프라인 리소스 생성 화면에 description 추가 요청
[원인] description 없음
[해결] description 추가

[feat] add status for helm
helm Status 추가, ICON 추가 필요