### PR TITLE
Cluster 액세스권한 탭 페이지 관련 수정사항들

### DIFF
--- a/frontend/public/components/hypercloud/members.tsx
+++ b/frontend/public/components/hypercloud/members.tsx
@@ -72,7 +72,7 @@ const MemberTableHeader = (t?: TFunction) => {
 MemberTableHeader.displayName = 'UserTableHeader';
 
 export const UsersTable = props => {
-  const { isOwner, owner, members, heading, searchType, searchKey } = props;
+  const { isOwner, owner, members, heading, searchType, searchKey, rerenderPage } = props;
 
   const { t } = useTranslation();
   const ownerRow = owner ? ownerData.bind(null, owner, t)() : [];
@@ -119,13 +119,13 @@ export const UsersTable = props => {
       {
         title: t('COMMON:MSG_DETAILS_TABACCESSPERMISSIONS_ACTIONBUTTON_1'),
         onClick: (event, rowId, rowData, extra) => {
-          modifyMemberModal({ modalClassName: 'modal-lg', member: rowData.obj });
+          modifyMemberModal({ modalClassName: 'modal-lg', member: rowData.obj, rerenderPage: rerenderPage });
         },
       },
       {
         title: t('COMMON:MSG_DETAILS_TABACCESSPERMISSIONS_ACTIONBUTTON_2'),
         onClick: (event, rowId, rowData, extra) => {
-          removeMemberModal({ modalClassName: 'modal-lg', member: rowData.obj });
+          removeMemberModal({ modalClassName: 'modal-lg', member: rowData.obj, rerenderPage: rerenderPage });
         },
       },
     ];
@@ -167,6 +167,7 @@ export const MembersPage = props => {
   const [searchType, setSearchType] = React.useState('MemberName');
   const [searchKey, setSearchKey] = React.useState('');
   const [isOpen, setOpen] = React.useState(false);
+  const [shouldRerender, setShouldRerender] = React.useState(false);
 
   const onToggle = (open: boolean) => setOpen(open);
   const onSelect = event => {
@@ -189,6 +190,7 @@ export const MembersPage = props => {
   ];
 
   React.useEffect(() => {
+    shouldRerender === true && setShouldRerender(false);
     coFetchJSON(`/api/multi-hypercloud/namespaces/${props.namespace}/clustermanagers/${props.clusterName}/member?userId=${getId()}${getUserGroup()}`, 'GET')
       .then(res => {
         let idx = _.findIndex(res, (mem: RowMemberData) => mem.Status === 'owner');
@@ -199,7 +201,7 @@ export const MembersPage = props => {
       .catch(err => {
         console.log('Fail to get member list. ' + err);
       });
-  }, []);
+  }, [shouldRerender]);
 
   const isOwner = props.owner === getId();
   const { t } = useTranslation();
@@ -219,14 +221,14 @@ export const MembersPage = props => {
         <TextInput className="hc-members__search" value={searchKey} onChange={handleTextInputChange} placeholder={searchType === 'MemberId' ? t('search by email') : t('search by name')}></TextInput>
         {isOwner && (
           <div className="co-m-primary-action">
-            <Button variant="primary" id="yaml-create" onClick={() => inviteMemberModal({ namespace: props.namespace, clusterName: props.clusterName, modalClassName: 'hc-invite-modal__container', existMembers: members })}>
+            <Button variant="primary" id="yaml-create" onClick={() => inviteMemberModal({ namespace: props.namespace, clusterName: props.clusterName, modalClassName: 'hc-invite-modal__container', existMembers: members, rerenderPage: setShouldRerender })}>
               {t('MULTI:MSG_MULTI_CLUSTERS_INVITEPEOPLEPOPUP_BUTTON_1')}
             </Button>
           </div>
         )}
       </div>
       <div className="hc-members__body">
-        <UsersTable clusterName={props.clusterName} isOwner={isOwner} owner={owner} members={members} searchType={searchType} searchKey={searchKey} />
+        <UsersTable clusterName={props.clusterName} isOwner={isOwner} owner={owner} members={members} searchType={searchType} searchKey={searchKey} rerenderPage={setShouldRerender} />
       </div>
     </>
   );

--- a/frontend/public/components/hypercloud/members.tsx
+++ b/frontend/public/components/hypercloud/members.tsx
@@ -23,14 +23,15 @@ const tableColumnClasses = ['', '', classNames('pf-m-hidden', 'pf-m-visible-on-s
 const MemberTableRows = (members): ITableRow[] => {
   const data = [];
   _.forEach(members, member => {
+    const memberName = !!member.MemberName ? member.MemberName : member.MemberId?.split('@')[0];
     data.push({
       cells: [
         member.Attribute === 'user' ? (
-          member.MemberName
+          memberName
         ) : (
           <>
             <UsersIcon className="hc-member__group-icon" />
-            {member.MemberName}
+            {memberName}
           </>
         ),
         member.MemberId,

--- a/frontend/public/components/hypercloud/modals/invite-member-modal.tsx
+++ b/frontend/public/components/hypercloud/modals/invite-member-modal.tsx
@@ -122,7 +122,7 @@ const getRowMemberData = members => members.map(member => (Array.isArray(member)
 
 export const InviteMemberModal = withHandlePromise((props: InviteMemberModalProps) => {
   const { t } = useTranslation();
-  const { handlePromise, errorMessage, inProgress, close, cancel } = props;
+  const { handlePromise, errorMessage, inProgress, close, cancel, rerenderPage } = props;
   const [type, setType] = React.useState('user');
   const [role, setRole] = React.useState('admin');
   const [selectedMember, setSelectedMember] = React.useState({ name: '', email: '' });
@@ -229,6 +229,7 @@ export const InviteMemberModal = withHandlePromise((props: InviteMemberModalProp
       const memberEmail = type === 'user' ? selectedMember.email : selectedMember.name;
       const promise = coFetchJSON(`/api/multi-hypercloud/namespaces/${props.namespace}/clustermanagers/${props.clusterName}/member_invitation/${type}/${memberEmail}?userId=${getId()}${getUserGroup()}&remoteRole=${role}`, 'POST');
       handlePromise(promise).then(close);
+      rerenderPage(true);
     }
   };
 
@@ -317,5 +318,6 @@ export type InviteMemberModalProps = {
   type: string;
   existMembers: string[];
   existGroups: string[];
+  rerenderPage?: any;
 } & ModalComponentProps &
   HandlePromiseProps;

--- a/frontend/public/components/hypercloud/modals/modify-member-modal.tsx
+++ b/frontend/public/components/hypercloud/modals/modify-member-modal.tsx
@@ -1,13 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 
-import {
-  ModalBody,
-  ModalComponentProps,
-  ModalSubmitFooter,
-  ModalTitle,
-  createModalLauncher,
-} from '../../factory/modal';
+import { ModalBody, ModalComponentProps, ModalSubmitFooter, ModalTitle, createModalLauncher } from '../../factory/modal';
 import { HandlePromiseProps, withHandlePromise } from '../../utils';
 import { Section } from '../utils/section';
 import { RadioGroup } from '@console/internal/components/radio';
@@ -27,40 +21,32 @@ const roleItems = (t?: TFunction) => [
   },
   {
     title: t('COMMON:MSG_DETAILS_TABACCESSPERMISSIONS_RADIOBUTTON_3'),
-    value: 'guest'
+    value: 'guest',
   },
 ];
 
-
 export const ModifyMemberModal = withHandlePromise((props: ModifyMemberModalProps) => {
   const [role, setRole] = React.useState(props.member.Role);
-  const [errorMsg, setError] = React.useState('')
+  const [errorMsg, setError] = React.useState('');
 
-  const submit: React.FormEventHandler<HTMLFormElement> = (e) => {
+  const submit: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault();
     coFetchJSON(`/api/multi-hypercloud/namespaces/${props.member.Namespace}/clustermanagers/${props.member.Cluster}/update_role/${props.member.Attribute}/${props.member.MemberId}?userId=${getId()}${getUserGroup()}&remoteRole=${role}`, 'PUT')
-      .then((res) => {
+      .then(res => {
         props.close();
       })
-      .catch((err) => {
+      .catch(err => {
         setError(err);
-      })
+      });
   };
 
   const { t } = useTranslation();
   return (
     <form onSubmit={submit} name="form" className="modal-content ">
-      <ModalTitle>
-        {t('MULTI:MSG_MULTI_CLUSTERS_CHANGEPERMISSIONSPOPUP_TITLE_1')}
-      </ModalTitle>
+      <ModalTitle>{t('MULTI:MSG_MULTI_CLUSTERS_CHANGEPERMISSIONSPOPUP_TITLE_1')}</ModalTitle>
       <ModalBody className="modal-body">
-        <Section id='role'>
-          <RadioGroup
-            id='role'
-            currentValue={role}
-            items={roleItems.bind(null, t)()}
-            onChange={({ currentTarget }) => setRole(currentTarget.value)}
-          />
+        <Section id="role">
+          <RadioGroup id="role" currentValue={role} items={roleItems.bind(null, t)()} onChange={({ currentTarget }) => setRole(currentTarget.value)} />
         </Section>
       </ModalBody>
       <ModalSubmitFooter errorMessage={errorMsg} inProgress={props.inProgress} submitText={t('COMMON:MSG_COMMON_BUTTON_COMMIT_3')} cancelText={t('COMMON:MSG_COMMON_BUTTON_COMMIT_2')} cancel={props.cancel} />
@@ -72,16 +58,16 @@ export const modifyMemberModal = createModalLauncher(ModifyMemberModal);
 
 export type ModifyMemberModalProps = {
   member: {
-    Id?: number,
-    Namespace?: string,
-    Cluster?: string,
-    MemberId: string,
-    MemberName: string,
-    Attribute: "group" | "user",
-    Role: "guest" | "developer" | "admin",
-    Status?: "invited" | "owner",
-    CreatedTime?: string,
-    UpdatedTime?: string
+    Id?: number;
+    Namespace?: string;
+    Cluster?: string;
+    MemberId: string;
+    MemberName: string;
+    Attribute: 'group' | 'user';
+    Role: 'guest' | 'developer' | 'admin';
+    Status?: 'invited' | 'owner';
+    CreatedTime?: string;
+    UpdatedTime?: string;
   };
 } & ModalComponentProps &
   HandlePromiseProps;

--- a/frontend/public/components/hypercloud/modals/modify-member-modal.tsx
+++ b/frontend/public/components/hypercloud/modals/modify-member-modal.tsx
@@ -26,18 +26,14 @@ const roleItems = (t?: TFunction) => [
 ];
 
 export const ModifyMemberModal = withHandlePromise((props: ModifyMemberModalProps) => {
+  const { handlePromise, close, cancel, inProgress, errorMessage, rerenderPage } = props;
   const [role, setRole] = React.useState(props.member.Role);
-  const [errorMsg, setError] = React.useState('');
 
   const submit: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault();
-    coFetchJSON(`/api/multi-hypercloud/namespaces/${props.member.Namespace}/clustermanagers/${props.member.Cluster}/update_role/${props.member.Attribute}/${props.member.MemberId}?userId=${getId()}${getUserGroup()}&remoteRole=${role}`, 'PUT')
-      .then(res => {
-        props.close();
-      })
-      .catch(err => {
-        setError(err);
-      });
+    const promise = coFetchJSON(`/api/multi-hypercloud/namespaces/${props.member.Namespace}/clustermanagers/${props.member.Cluster}/update_role/${props.member.Attribute}/${props.member.MemberId}?userId=${getId()}${getUserGroup()}&remoteRole=${role}`, 'PUT');
+    handlePromise(promise).then(close);
+    rerenderPage(true);
   };
 
   const { t } = useTranslation();
@@ -49,7 +45,7 @@ export const ModifyMemberModal = withHandlePromise((props: ModifyMemberModalProp
           <RadioGroup id="role" currentValue={role} items={roleItems.bind(null, t)()} onChange={({ currentTarget }) => setRole(currentTarget.value)} />
         </Section>
       </ModalBody>
-      <ModalSubmitFooter errorMessage={errorMsg} inProgress={props.inProgress} submitText={t('COMMON:MSG_COMMON_BUTTON_COMMIT_3')} cancelText={t('COMMON:MSG_COMMON_BUTTON_COMMIT_2')} cancel={props.cancel} />
+      <ModalSubmitFooter errorMessage={errorMessage} inProgress={inProgress} submitText={t('COMMON:MSG_COMMON_BUTTON_COMMIT_3')} cancelText={t('COMMON:MSG_COMMON_BUTTON_COMMIT_2')} cancel={cancel} />
     </form>
   );
 });
@@ -57,6 +53,7 @@ export const ModifyMemberModal = withHandlePromise((props: ModifyMemberModalProp
 export const modifyMemberModal = createModalLauncher(ModifyMemberModal);
 
 export type ModifyMemberModalProps = {
+  rerenderPage?: any;
   member: {
     Id?: number;
     Namespace?: string;

--- a/frontend/public/components/hypercloud/modals/remove-member-modal.tsx
+++ b/frontend/public/components/hypercloud/modals/remove-member-modal.tsx
@@ -9,17 +9,12 @@ import { getId, getUserGroup } from '../../../hypercloud/auth';
 import { useTranslation } from 'react-i18next';
 
 export const RemoveMemberModal = withHandlePromise((props: RemoveMemberModalProps) => {
-  const [errorMsg, setError] = React.useState('');
-
+  const { handlePromise, close, cancel, errorMessage, inProgress, rerenderPage } = props;
   const submit: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault(); ///cluster/cho/remove_member/group/ck1-3?userId=kubernetes-admin&userGroup=hypercloud5
-    coFetchJSON(`/api/multi-hypercloud/namespaces/${props.member.Namespace}/clustermanagers/${props.member.Cluster}/remove_member/${props.member.Attribute}/${props.member.MemberId}?userId=${getId()}${getUserGroup()}`, 'POST')
-      .then(res => {
-        props.close();
-      })
-      .catch(err => {
-        setError(err);
-      });
+    const promise = coFetchJSON(`/api/multi-hypercloud/namespaces/${props.member.Namespace}/clustermanagers/${props.member.Cluster}/remove_member/${props.member.Attribute}/${props.member.MemberId}?userId=${getId()}${getUserGroup()}`, 'POST');
+    handlePromise(promise).then(close);
+    rerenderPage(true);
   };
 
   const { t } = useTranslation();
@@ -33,7 +28,7 @@ export const RemoveMemberModal = withHandlePromise((props: RemoveMemberModalProp
       <ModalBody className="modal-body">
         <div>{t('MULTI:MSG_MULTI_CLUSTERS_DELETEPEPLEPOPUP_MAINMESSAGE_1', { 0: props.member.MemberName, 1: props.member.MemberId, 2: props.member.Cluster })}</div>
       </ModalBody>
-      <ModalSubmitFooter errorMessage={errorMsg} inProgress={props.inProgress} submitText={t('MULTI:MSG_MULTI_CLUSTERS_DELETEACCESSMEMBER_2')} cancelText={t('MULTI:MSG_MULTI_CLUSTERS_DELETEACCESSMEMBER_1')} cancel={props.cancel} />
+      <ModalSubmitFooter errorMessage={errorMessage} inProgress={inProgress} submitText={t('MULTI:MSG_MULTI_CLUSTERS_DELETEACCESSMEMBER_2')} cancelText={t('MULTI:MSG_MULTI_CLUSTERS_DELETEACCESSMEMBER_1')} cancel={cancel} />
     </form>
   );
 });
@@ -41,6 +36,7 @@ export const RemoveMemberModal = withHandlePromise((props: RemoveMemberModalProp
 export const removeMemberModal = createModalLauncher(RemoveMemberModal);
 
 export type RemoveMemberModalProps = {
+  rerenderPage?: any;
   member: {
     Id?: number;
     Namespace?: string;

--- a/frontend/public/components/hypercloud/modals/remove-member-modal.tsx
+++ b/frontend/public/components/hypercloud/modals/remove-member-modal.tsx
@@ -1,13 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 
-import {
-  ModalBody,
-  ModalComponentProps,
-  ModalSubmitFooter,
-  ModalTitle,
-  createModalLauncher,
-} from '../../factory/modal';
+import { ModalBody, ModalComponentProps, ModalSubmitFooter, ModalTitle, createModalLauncher } from '../../factory/modal';
 import { HandlePromiseProps, withHandlePromise } from '../../utils';
 import { YellowExclamationTriangleIcon } from '@console/shared';
 import { coFetchJSON } from '../../../co-fetch';
@@ -15,17 +9,17 @@ import { getId, getUserGroup } from '../../../hypercloud/auth';
 import { useTranslation } from 'react-i18next';
 
 export const RemoveMemberModal = withHandlePromise((props: RemoveMemberModalProps) => {
-  const [errorMsg, setError] = React.useState('')
+  const [errorMsg, setError] = React.useState('');
 
-  const submit: React.FormEventHandler<HTMLFormElement> = (e) => {
+  const submit: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault(); ///cluster/cho/remove_member/group/ck1-3?userId=kubernetes-admin&userGroup=hypercloud5
     coFetchJSON(`/api/multi-hypercloud/namespaces/${props.member.Namespace}/clustermanagers/${props.member.Cluster}/remove_member/${props.member.Attribute}/${props.member.MemberId}?userId=${getId()}${getUserGroup()}`, 'POST')
-      .then((res) => {
+      .then(res => {
         props.close();
       })
-      .catch((err) => {
+      .catch(err => {
         setError(err);
-      })
+      });
   };
 
   const { t } = useTranslation();
@@ -37,9 +31,7 @@ export const RemoveMemberModal = withHandlePromise((props: RemoveMemberModalProp
         {t('MULTI:MSG_MULTI_CLUSTERS_DELETEPEPLEPOPUP_TITLE_1')}
       </ModalTitle>
       <ModalBody className="modal-body">
-        <div>
-          {t('MULTI:MSG_MULTI_CLUSTERS_DELETEPEPLEPOPUP_MAINMESSAGE_1', { 0: props.member.MemberName, 1: props.member.MemberId, 2: props.member.Cluster })}
-        </div>
+        <div>{t('MULTI:MSG_MULTI_CLUSTERS_DELETEPEPLEPOPUP_MAINMESSAGE_1', { 0: props.member.MemberName, 1: props.member.MemberId, 2: props.member.Cluster })}</div>
       </ModalBody>
       <ModalSubmitFooter errorMessage={errorMsg} inProgress={props.inProgress} submitText={t('MULTI:MSG_MULTI_CLUSTERS_DELETEACCESSMEMBER_2')} cancelText={t('MULTI:MSG_MULTI_CLUSTERS_DELETEACCESSMEMBER_1')} cancel={props.cancel} />
     </form>
@@ -50,16 +42,16 @@ export const removeMemberModal = createModalLauncher(RemoveMemberModal);
 
 export type RemoveMemberModalProps = {
   member: {
-    Id?: number,
-    Namespace?: string,
-    Cluster?: string,
-    MemberId: string,
-    MemberName: string,
-    Attribute: "group" | "user",
-    Role: "guest" | "developer" | "admin",
-    Status?: "invited" | "owner",
-    CreatedTime?: string,
-    UpdatedTime?: string
+    Id?: number;
+    Namespace?: string;
+    Cluster?: string;
+    MemberId: string;
+    MemberName: string;
+    Attribute: 'group' | 'user';
+    Role: 'guest' | 'developer' | 'admin';
+    Status?: 'invited' | 'owner';
+    CreatedTime?: string;
+    UpdatedTime?: string;
   };
 } & ModalComponentProps &
   HandlePromiseProps;


### PR DESCRIPTION
* Cluster 디테일페이지의 액세스권한 탭에 보여지는 멤버리스트에서 '이름'이 없을 시 메일주소의 id를 대신 보여주도록 수정
* IMS 265949 : 액세스권한자 초대, 멤버 권한수정, 멤버 삭제 시 뜨는 모달에서 작업 후 모달이 닫힐 때 새로운 상태 refresh 되지 않는 이슈가 있었음. 리렌더를 통해 새로운 내용 반영되도록 수정함.
* ModifyMemberModal, RemoveMemberModal 코드 포매팅
* ModifyMemberModal, RemoveMemeberModal에서 createModalLauncher()에서 제공하는 props(errorMessage)를 활용하고 있지 않아 제대로 활용하도록 수정함