### PR TITLE
[refactor] Pipeline Edit,Create페이지 분기처리가 edit-resource가 아닌 create-pipeline.tsx에서 되도록 수정

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderEditPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderEditPage.tsx
@@ -9,7 +9,7 @@ import { PipelineModel } from '../../../models';
 
 import './PipelineBuilderEditPage.scss';
 
-type PipelineBuilderEditPageProps = RouteComponentProps<{ ns: string; name: string }>;
+type PipelineBuilderEditPageProps = { isCreate?: boolean } & RouteComponentProps<{ ns: string; name: string }>;
 
 const PipelineBuilderEditPage: React.FC<PipelineBuilderEditPageProps> = props => {
   const [editPipeline, setEditPipeline] = React.useState<Pipeline>(null);

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -15,7 +15,6 @@ import TaskSidebar from './task-sidebar/TaskSidebar';
 import { CleanupResults, PipelineBuilderTaskGroup, SelectedBuilderTask, UpdateErrors, UpdateOperationUpdateTaskData } from './types';
 import { applyChange } from './update-utils';
 import { useTranslation } from 'react-i18next';
-import { isCreatePage } from '../../../../../../public/components/hypercloud/form/create-form';
 //import { TFunction } from 'i18next';
 
 import './PipelineBuilderForm.scss';
@@ -23,6 +22,7 @@ import './PipelineBuilderForm.scss';
 type PipelineBuilderFormProps = FormikProps<FormikValues> & {
   existingPipeline: Pipeline;
   namespace: string;
+  isCreate?: boolean;
 };
 
 const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = props => {
@@ -32,7 +32,7 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = props => {
 
   const { t } = useTranslation();
 
-  const { existingPipeline, status, isSubmitting, dirty, handleReset, handleSubmit, errors, namespace, setFieldValue, setStatus, values } = props;
+  const { existingPipeline, status, isSubmitting, dirty, handleReset, handleSubmit, errors, namespace, setFieldValue, setStatus, values, isCreate } = props;
   const statusRef = React.useRef(status);
   statusRef.current = status;
 
@@ -77,7 +77,7 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = props => {
     <>
       <Stack className="odc-pipeline-builder-form">
         <StackItem>
-          <PipelineBuilderHeader existingPipeline={existingPipeline} namespace={namespace} isCreate={isCreatePage(existingPipeline)} />
+          <PipelineBuilderHeader existingPipeline={existingPipeline} namespace={namespace} isCreate={isCreate} />
         </StackItem>
         <StackItem isFilled className="odc-pipeline-builder-form__content">
           <Form className="odc-pipeline-builder-form__grid" onSubmit={handleSubmit}>

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderPage.tsx
@@ -23,6 +23,7 @@ import './PipelineBuilderPage.scss';
 
 type PipelineBuilderPageProps = RouteComponentProps<{ ns?: string }> & {
   existingPipeline?: Pipeline;
+  isCreate?: boolean;
 };
 
 const PipelineBuilderPage: React.FC<PipelineBuilderPageProps> = (props) => {
@@ -88,6 +89,7 @@ const PipelineBuilderPage: React.FC<PipelineBuilderPageProps> = (props) => {
             {...formikProps}
             namespace={ns}
             existingPipeline={existingPipeline}
+            isCreate={props.isCreate}
           />
         )}
       />

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -193,8 +193,6 @@ const AppContents_: React.FC<AppContentsProps> = ({ activePerspective }) => (
           <LazyRoute path="/k8s/ns/:ns/customresourcedefinitions/:plural/~new" exact />
           <LazyRoute path="/k8s/cluster/rolebindings/~new" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.CreateRoleBinding)} kind="RoleBinding" />
           <LazyRoute path="/k8s/ns/:ns/rolebindings/~new" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.CreateRoleBinding)} kind="RoleBinding" />
-          <LazyRoute path="/k8s/cluster/pipelines/~new" exact loader={() => import('../../packages/dev-console/src/components/pipelines/pipeline-builder' /* webpackChunkName: "PipelineBuilderPage" */).then(m => m.PipelineBuilderPage)} kind="Pipeline" />
-          <LazyRoute path="/k8s/ns/:ns/pipelines/~new" exact loader={() => import('../../packages/dev-console/src/components/pipelines/pipeline-builder' /* webpackChunkName: "PipelineBuilderPage" */).then(m => m.PipelineBuilderPage)} kind="Pipeline" />
           <LazyRoute path="/k8s/ns/:ns/:plural/~new/" exact />
           <LazyRoute path="/k8s/cluster/:plural/~new/" exact />
           <LazyRoute path="/k8s/ns/:ns/routes/~new/form" exact kind="Route" loader={() => import('./routes/create-route' /* webpackChunkName: "create-route" */).then(m => m.CreateRoute)} />

--- a/frontend/public/components/hypercloud/crd/edit-resource.tsx
+++ b/frontend/public/components/hypercloud/crd/edit-resource.tsx
@@ -151,15 +151,7 @@ export const EditDefaultPage = connect(stateToProps)((props: EditDefaultPageProp
       <Helmet>
         <title>{`Edit ${kind}`}</title>
       </Helmet>
-      {isCreateManual(kind) ? (
-        kind === 'Pipeline' ? (
-          <AsyncComponent loader={() => import('../../../../packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderEditPage').then(m => m.default)} obj={props.obj} match={props.match} />
-        ) : (
-          <AsyncComponent loader={() => import(`../form/${plural}/create-${kind.toLowerCase()}`).then(m => m[`Create${kind}`])} obj={props.obj} match={props.match} />
-        )
-      ) : (
-        <EditDefault {...(props as any)} model={props.model} match={props.match} initialEditorType={EditorType.Form} create={false} />
-      )}
+      {isCreateManual(kind) ? <AsyncComponent loader={() => import(`../form/${plural}/create-${kind.toLowerCase()}`).then(m => m[`Create${kind}`])} obj={props.obj} match={props.match} /> : <EditDefault {...(props as any)} model={props.model} match={props.match} initialEditorType={EditorType.Form} create={false} />}
     </>
   );
 });

--- a/frontend/public/components/hypercloud/form/pipelines/create-pipeline.tsx
+++ b/frontend/public/components/hypercloud/form/pipelines/create-pipeline.tsx
@@ -1,3 +1,12 @@
+import * as React from 'react';
 import { PipelineBuilderPage } from '../../../../../packages/dev-console/src/components/pipelines/pipeline-builder';
-
-export const CreatePipeline = PipelineBuilderPage;
+import { default as PipelineBuilderEditPage } from '../../../../../packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderEditPage';
+import { isCreatePage } from '../create-form';
+/* MEMO : Pipeline Form은 기존에 구현된 Page들을 재사용함. */
+export const CreatePipeline = props => {
+  if (!!props.obj && !isCreatePage(props.obj)) {
+    return <PipelineBuilderEditPage {...props} isCreate={false} />;
+  } else {
+    return <PipelineBuilderPage {...props} isCreate={true} />;
+  }
+};


### PR DESCRIPTION
* Pipeline페이지는 오픈쉬프트에서 구현돼있던 생성/수정Form을 재사용하고 있는데, edit-resource.tsx에서 리소스kind가 Pipeline일 경우에만 분기처리해주는 것보다 CreatePipeline 컴포넌트 안에서 Edit/Create을 구별하여 분기처리 해주는것이 더 나을듯하여 리팩토링함.