### PR TITLE
테스트코드 샘플 추가

### DIFF
--- a/frontend/__hypercloud_tests__/components/RadioGroup.spec.tsx
+++ b/frontend/__hypercloud_tests__/components/RadioGroup.spec.tsx
@@ -37,7 +37,7 @@ describe('RadioGroupTestSample', () => {
     });
   });
 
-  it('radio group render first element', async () => {
+  it('radio group items rendered', async () => {
     expect(wrapper.debug()).toMatchSnapshot();
     expect(wrapper.find(RadioInput).exists()).toBe(true);
     expect(wrapper.find(RadioInput).length).toBe(3);

--- a/frontend/__hypercloud_tests__/components/RadioGroup.spec.tsx
+++ b/frontend/__hypercloud_tests__/components/RadioGroup.spec.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { RadioInput, RadioGroup } from '../../public/components/hypercloud/utils/radio';
+import { mount, ReactWrapper } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import { useForm, FormProvider } from 'react-hook-form';
+
+describe('RadioGroupTestSample', () => {
+  let wrapper: ReactWrapper;
+
+  beforeEach(async () => {
+    const resources = [
+      {
+        title: 'Cpu',
+        value: 'cpu',
+      },
+      {
+        title: 'Gpu',
+        value: 'gpu',
+      },
+      {
+        title: 'Memory',
+        value: 'memory',
+      },
+    ];
+
+    await act(async () => {
+      wrapper = mount(<RadioGroup name="radio-group" items={resources} inline={false} />, {
+        wrappingComponent: ({ children }) => {
+          const methods = useForm();
+          return (
+            <FormProvider {...methods}>
+              <form>{children}</form>
+            </FormProvider>
+          );
+        },
+      });
+    });
+  });
+
+  it('radio group render first element', async () => {
+    expect(wrapper.debug()).toMatchSnapshot();
+    expect(wrapper.find(RadioInput).exists()).toBe(true);
+    expect(wrapper.find(RadioInput).length).toBe(3);
+  });
+});


### PR DESCRIPTION
* RadioGroup 공통컴포넌트 렌더시 설정해준 items값에 따라 개수가 맞게 나오는지 테스트하는 코드 샘플 추가
* html구성 보는 스냅샷 구문도 추가함
* frontend 폴더에서 yarn run test-hypercloud 커맨드로 실행가능