### PR TITLE
[bugfix][patch][IMS]265683 파이프라인 edit시 폼뷰가 나오지 않음 - sidebar bugfix

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
@@ -116,9 +116,15 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
             <h2>{t('SINGLE:MSG_PIPELINES_CREATEFORM_26')}</h2>
             {params.map((param) => {
               const taskParams: PipelineTaskParam[] = taskField.value?.params || [];
-              const thisParam = taskParams.find(
+              let thisParam = taskParams.find(
                 (taskFieldParam) => taskFieldParam.name === param.name,
               );
+              if (thisParam === undefined ) {
+                thisParam = {
+                  value: '',
+                  name: param.name,
+                }
+              }
               return (
                 <div key={param.name} className="odc-task-sidebar__param">
                   <TaskSidebarParam

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
@@ -116,19 +116,13 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
             <h2>{t('SINGLE:MSG_PIPELINES_CREATEFORM_26')}</h2>
             {params.map((param) => {
               const taskParams: PipelineTaskParam[] = taskField.value?.params || [];
-              let thisParam = taskParams.find(
+              const thisParam = taskParams.find(
                 (taskFieldParam) => taskFieldParam.name === param.name,
               );
-              if (thisParam === undefined ) {
-                thisParam = {
-                  value: '',
-                  name: param.name,
-                }
-              }
               return (
                 <div key={param.name} className="odc-task-sidebar__param">
                   <TaskSidebarParam
-                    hasParamError={!thisParam.value && !!thisTaskError?.includes(TaskErrorType.MISSING_REQUIRED_PARAMS)}
+                    hasParamError={!thisParam?.value && !!thisTaskError?.includes(TaskErrorType.MISSING_REQUIRED_PARAMS)}
                     resourceParam={param}
                     taskParam={thisParam}
                     onChange={(value) => {


### PR DESCRIPTION
[현상] pipeline 수정 페이지에서 특정 task 수정시 에러페이지 나옴
[원인] Task의 파라미터 중 값이 빈 파라미터가 있으면 sidebar 호출시 값이 없어서 에러가 발생
[해결] 빈 파라미터일때 빈 string 값 넣어줌