### PR TITLE
Dev/hyowook

### DIFF
--- a/frontend/packages/topology/src/Visualization.ts
+++ b/frontend/packages/topology/src/Visualization.ts
@@ -50,6 +50,7 @@ export default class Visualization extends Stateful implements Controller {
 
     // create elements
     if (model.graph) {
+      model.graph.id = model.graph.id + '_graph';
       this.graph = this.createElement<Graph>(ModelKind.graph, model.graph);
     }
     const validIds: string[] = [];


### PR DESCRIPTION
[현상] 

파이프라인 생성에서 파이프라인과 같은 이름인 태스크를 넣고 생성하면,

파이프라인 상세에서는 보이지 않고, 파이프라인 수정에서는 보이는 문제

이때 파이프라인 수정에서 추가로 노드를 연결하면 에러 발생

[원인] graph 이름과 node 이름이 같으면 표시 안되는 문제

상세 페이지에서 graph 이름은 pipeline 이름과 같음

수정에서는 graph 이름이 pipeline-builder 로 고정됨

pipeline-builder 라는 node를 생성했을때는 상세에서는 보이고, 수정에서 보이지않음

createElement 에서 graph 이름(pipeline 이름)과 node 이름(task 이름)을 id로 쓰고 있는데 동일한 id를 가진 개체를 다시 만들어 주지 않음


[해결] graph id에 뒤에 '_graph' 붙여줌