### PR TITLE
Topology 관련 리팩토링

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -21,7 +21,7 @@ import { GraphData, TopologyDataModel, TopologyDataObject, SHOW_GROUPING_HINT_EV
 import TopologyResourcePanel from './TopologyResourcePanel';
 import TopologyApplicationPanel from './application-panel/TopologyApplicationPanel';
 import ConnectedTopologyEdgePanel from './TopologyEdgePanel';
-import { topologyModelFromDataModel } from './data-transforms/topology-model';
+import { topologyModelFromDataModel } from './data-transforms/hypercloud/topology-model';
 import { layoutFactory, COLA_LAYOUT, COLA_FORCE_LAYOUT } from './layouts/layoutFactory';
 import { TYPE_APPLICATION_GROUP, TYPE_DEPLOYMENT_GROUP, TYPE_STATEFULSET_GROUP, TYPE_DAEMONSET_GROUP, TYPE_REPLICASET_GROUP, ComponentFactory } from './components';
 import TopologyFilterBar from './filters/TopologyFilterBar';

--- a/frontend/packages/dev-console/src/components/topology/components/hypercloud/groups/DaemonSet.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/hypercloud/groups/DaemonSet.scss
@@ -9,9 +9,9 @@
   }
 
   &__bg {
-    fill: var(--pf-global--Color--light-100);
+    fill: #a0caaab8;
     fill-opacity: 0.6;
-    stroke: var(--pf-global--Color--light-100);
+    stroke: #2c754f;
     stroke-width: 5px;
   }
 

--- a/frontend/packages/dev-console/src/components/topology/components/hypercloud/groups/Deployment.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/hypercloud/groups/Deployment.scss
@@ -9,9 +9,9 @@
   }
 
   &__bg {
-    fill: var(--pf-global--Color--light-100);
+    fill: #6c97ec33;
     fill-opacity: 0.6;
-    stroke: var(--pf-global--Color--light-100);
+    stroke: #4556b9;
     stroke-width: 5px;
   }
 

--- a/frontend/packages/dev-console/src/components/topology/components/hypercloud/groups/Deployment.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/hypercloud/groups/Deployment.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Node, observer, WithDndDropProps, WithSelectionProps, WithContextMenuProps } from '@console/topology';
 import { SHOW_GROUPING_HINT_EVENT } from '../../../topology-types';
 import { RegroupHint } from '../../RegroupHint';
-import DamonSetNode from './DamonSetNode';
+import DeploymentNode from './DeploymentNode';
 import DeploymentGroup from './DeploymentGroup';
 
 import './Deployment.scss';
@@ -29,7 +29,7 @@ const ObservedDeployment: React.FC<DeploymentProps> = ({ element, selected, onSe
   }, [dropTarget, canDrop, element, dragRegroupable]);
 
   if (element.isCollapsed()) {
-    return <DamonSetNode element={element} selected={selected} onSelect={onSelect} dndDropRef={dndDropRef} canDrop={canDrop} dropTarget={dropTarget} onContextMenu={onContextMenu} contextMenuOpen={contextMenuOpen} dragging={dragging} />;
+    return <DeploymentNode element={element} selected={selected} onSelect={onSelect} dndDropRef={dndDropRef} canDrop={canDrop} dropTarget={dropTarget} onContextMenu={onContextMenu} contextMenuOpen={contextMenuOpen} dragging={dragging} />;
   }
 
   return <DeploymentGroup element={element} selected={selected} onSelect={onSelect} dndDropRef={dndDropRef} canDrop={canDrop} dropTarget={dropTarget} droppable={droppable} onContextMenu={onContextMenu} contextMenuOpen={contextMenuOpen} dragging={dragging} />;

--- a/frontend/packages/dev-console/src/components/topology/components/hypercloud/groups/ReplicaSet.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/hypercloud/groups/ReplicaSet.scss
@@ -9,10 +9,10 @@
   }
 
   &__bg {
-    fill: var(--pf-global--Color--light-100);
+    fill: #bebee2;
     fill-opacity: 0.6;
-    stroke: var(--pf-global--Color--light-100);
-    stroke-width: 5px;
+    stroke: #5b3798;
+    stroke-width: 1px;
   }
 
   &.is-filtered &__bg {

--- a/frontend/packages/dev-console/src/components/topology/components/hypercloud/groups/ReplicaSetGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/hypercloud/groups/ReplicaSetGroup.tsx
@@ -54,6 +54,7 @@ const ReplicaSetGroup: React.FC<ReplicaSetGroupProps> = ({ element, selected, on
   const displayFilters = useDisplayFilters();
   const showLabels = displayFilters.showLabels || hover;
 
+  const { x, y, width, height } = element.getBounds();
   // cast to number and coerce
   const padding = maxPadding(element.getStyle<NodeStyle>().padding);
   const hullPadding = (point: PointWithSize | PointTuple) => (point[2] || 0) + padding;
@@ -117,7 +118,8 @@ const ReplicaSetGroup: React.FC<ReplicaSetGroupProps> = ({ element, selected, on
             'is-filtered': filtered,
           })}
         >
-          <path ref={dndDropRef} className="odc-replicaset-group__bg" filter={createSvgIdUrl(hover || labelHover || dragging || contextMenuOpen || dropTarget ? NODE_SHADOW_FILTER_ID_HOVER : NODE_SHADOW_FILTER_ID)} d={pathRef.current} />
+          <rect ref={dndDropRef} className="odc-replicaset-group__bg" filter={createSvgIdUrl(hover || labelHover || dragging || contextMenuOpen || dropTarget ? NODE_SHADOW_FILTER_ID_HOVER : NODE_SHADOW_FILTER_ID)} x={x} y={y} width={width} height={height} rx="5" ry="5" />
+          {/* <path ref={dndDropRef} className="odc-replicaset-group__bg" filter={createSvgIdUrl(hover || labelHover || dragging || contextMenuOpen || dropTarget ? NODE_SHADOW_FILTER_ID_HOVER : NODE_SHADOW_FILTER_ID)} d={pathRef.current} /> */}
         </g>
       </Layer>
       {showLabels && (

--- a/frontend/packages/dev-console/src/components/topology/components/hypercloud/groups/StatefulSet.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/hypercloud/groups/StatefulSet.scss
@@ -9,9 +9,9 @@
   }
 
   &__bg {
-    fill: var(--pf-global--Color--light-100);
+    fill: #e0dbade7;
     fill-opacity: 0.6;
-    stroke: var(--pf-global--Color--light-100);
+    stroke: #ffed43;
     stroke-width: 5px;
   }
 

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/hypercloud/topology-model.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/hypercloud/topology-model.ts
@@ -1,0 +1,129 @@
+import { EdgeModel, Model, NodeModel, createAggregateEdges } from '@console/topology';
+import { ALL_APPLICATIONS_KEY } from '@console/shared/src';
+import { TopologyFilters } from '../../filters';
+import { TopologyDataModel, TopologyDataObject, Node, Group } from '../../topology-types';
+import { TYPE_APPLICATION_GROUP, TYPE_AGGREGATE_EDGE, NODE_WIDTH, NODE_HEIGHT, NODE_PADDING, GROUP_WIDTH, GROUP_HEIGHT, GROUP_PADDING, TYPE_STATEFULSET_GROUP, TYPE_DEPLOYMENT_GROUP, TYPE_REPLICASET_GROUP, TYPE_DAEMONSET_GROUP } from '../../components/const';
+import { dataObjectFromModel } from '../transform-utils';
+
+const getApplicationGroupForNode = (node: Node, groups: NodeModel[]): NodeModel => {
+  const group = groups.find(g => g.children.includes(node.id));
+  if (!group) {
+    return null;
+  }
+  if (group.type === TYPE_APPLICATION_GROUP) {
+    return group;
+  }
+  return getApplicationGroupForNode(group, groups);
+};
+
+const getHyperCloudGroupModel = (d: Group, model: TopologyDataModel, filters: TopologyFilters): NodeModel => {
+  switch (d.type) {
+    case TYPE_DEPLOYMENT_GROUP:
+    case TYPE_REPLICASET_GROUP:
+    case TYPE_DAEMONSET_GROUP:
+    case TYPE_STATEFULSET_GROUP: {
+      const data: TopologyDataObject = model.topology[d.id] || dataObjectFromModel(d);
+      data.groupResources = d.nodes.map(id => model.topology[id]);
+      return {
+        width: GROUP_WIDTH,
+        height: GROUP_HEIGHT,
+        id: d.id,
+        group: true,
+        type: d.type,
+        visible: true,
+        collapsed: filters && !filters.display.workloadGrouping,
+        data,
+        children: d.nodes,
+        label: d.name,
+        style: {
+          padding: GROUP_PADDING,
+        },
+      };
+    }
+    default: {
+      return null;
+    }
+  }
+};
+
+export const topologyModelFromDataModel = (dataModel: TopologyDataModel, application: string = ALL_APPLICATIONS_KEY, filters?: TopologyFilters): Model => {
+  const groupNodes: NodeModel[] = dataModel.graph.groups.map(d => {
+    let node = getHyperCloudGroupModel(d, dataModel, filters);
+    if (node) {
+      return node;
+    }
+
+    const data: TopologyDataObject = dataModel.topology[d.id] || dataObjectFromModel(d);
+    data.groupResources = d.nodes.map(id => dataModel.topology[id]);
+
+    return {
+      width: GROUP_WIDTH,
+      height: GROUP_HEIGHT,
+      id: d.id,
+      group: true,
+      type: d.type,
+      visible: d.type !== TYPE_APPLICATION_GROUP || application === ALL_APPLICATIONS_KEY || d.name === application,
+      collapsed: filters && d.type === TYPE_APPLICATION_GROUP && !filters.display.appGrouping,
+      data,
+      children: d.nodes,
+      label: d.name,
+      style: {
+        padding: GROUP_PADDING,
+      },
+    };
+  });
+
+  const nodes: NodeModel[] = dataModel.graph.nodes.map(d => {
+    return {
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
+      id: d.id,
+      type: d.type,
+      label: dataModel.topology[d.id].name,
+      data: dataModel.topology[d.id],
+      visible: true,
+      style: {
+        padding: NODE_PADDING,
+      },
+    };
+  });
+
+  const allNodes = [...nodes, ...groupNodes];
+
+  // Flag any hidden nodes
+  if (application !== ALL_APPLICATIONS_KEY) {
+    const allGroups = [...groupNodes, ...nodes.filter(n => n.group)];
+    allNodes
+      .filter(g => g.type !== TYPE_APPLICATION_GROUP)
+      .forEach(g => {
+        const group = getApplicationGroupForNode(g, allGroups);
+        const hidden = application !== ALL_APPLICATIONS_KEY && (!group || application !== group.label);
+        g.visible = !hidden;
+      });
+  }
+
+  // create links from data, only include those which have a valid source and target
+  const edges = dataModel.graph.edges
+    .filter(d => {
+      return allNodes.find(n => n.id === d.source) && allNodes.find(n => n.id === d.target);
+    })
+    .map(
+      (d): EdgeModel => {
+        return {
+          data: d,
+          source: d.source,
+          target: d.target,
+          id: `${d.source}_${d.target}`,
+          type: d.type,
+        };
+      },
+    );
+
+  // create topology model
+  const model: Model = {
+    nodes: allNodes,
+    edges: createAggregateEdges(TYPE_AGGREGATE_EDGE, edges, allNodes),
+  };
+
+  return model;
+};

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/hypercloud/topology-model.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/hypercloud/topology-model.ts
@@ -31,7 +31,7 @@ const getHyperCloudGroupModel = (d: Group, model: TopologyDataModel, filters: To
         group: true,
         type: d.type,
         visible: true,
-        collapsed: filters && !filters.display.workloadGrouping,
+        collapsed: filters && d.type !== TYPE_DEPLOYMENT_GROUP && !filters.display.workloadGrouping,
         data,
         children: d.nodes,
         label: d.name,

--- a/frontend/packages/dev-console/src/components/topology/filters/__tests__/FilterDropdown.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/__tests__/FilterDropdown.spec.tsx
@@ -11,6 +11,7 @@ const VALID_FILTERS = {
   showLabels: true,
   knativeServices: true,
   appGrouping: true,
+  workloadGrouping: true,
   operatorGrouping: true,
   helmGrouping: true,
 };

--- a/frontend/packages/dev-console/src/components/topology/filters/filter-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/filters/filter-types.ts
@@ -2,18 +2,18 @@ export const TOPOLOGY_SEARCH_FILTER_KEY = 'searchQuery';
 export const FILTER_ACTIVE_CLASS = 'odc-m-filter-active';
 
 export enum ShowFiltersKeyValue {
-  podCount = 'Pod Count',
-  eventSources = 'Event Sources',
-  virtualMachines = 'Virtual Machines',
+  // podCount = 'Pod Count',
+  // eventSources = 'Event Sources',
+  // virtualMachines = 'Virtual Machines',
   showLabels = 'Show Labels',
 }
 
 export enum ExpandFiltersKeyValue {
   appGrouping = 'Application Groupings',
   workloadGrouping = 'Workload Groupings',
-  helmGrouping = 'Helm Releases',
-  knativeServices = 'Knative Services',
-  operatorGrouping = 'Operator Groupings',
+  // helmGrouping = 'Helm Releases',
+  // knativeServices = 'Knative Services',
+  // operatorGrouping = 'Operator Groupings',
 }
 
 export type TopologyFilters = {

--- a/frontend/packages/dev-console/src/components/topology/filters/filter-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/filters/filter-types.ts
@@ -10,6 +10,7 @@ export enum ShowFiltersKeyValue {
 
 export enum ExpandFiltersKeyValue {
   appGrouping = 'Application Groupings',
+  workloadGrouping = 'Workload Groupings',
   helmGrouping = 'Helm Releases',
   knativeServices = 'Knative Services',
   operatorGrouping = 'Operator Groupings',
@@ -26,6 +27,7 @@ export type DisplayFilters = {
   showLabels: boolean;
   knativeServices: boolean;
   appGrouping: boolean;
+  workloadGrouping: boolean;
   operatorGrouping: boolean;
   helmGrouping: boolean;
 };

--- a/frontend/packages/dev-console/src/components/topology/redux/const.ts
+++ b/frontend/packages/dev-console/src/components/topology/redux/const.ts
@@ -2,12 +2,13 @@ export const TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY = `bridge/topology-displ
 export const DEFAULT_TOPOLOGY_FILTERS = {
   display: {
     podCount: false,
-    eventSources: true,
-    virtualMachines: true,
+    eventSources: false,
+    virtualMachines: false,
     showLabels: true,
     knativeServices: true,
     appGrouping: true,
-    operatorGrouping: true,
-    helmGrouping: true,
+    workloadGrouping: true,
+    operatorGrouping: false,
+    helmGrouping: false,
   },
 };


### PR DESCRIPTION
* 토폴로지 필터에서 불필요한 필터항목들 제거 및 Workload Grouping 아이템 추가(Deployment, DaemonSet, ReplicaSet, StatefulSet 그룹핑 여부 설정해주는 필터)
* Topology 노드컴포넌트들 색상으로 구분 (아직 기획은 없지만 쉬운 구별을 위해 색상 변경해놓음)
* topology-model.ts파일 hypercloud폴더로 분리
  * ApplicationGroup에 대한 부분은 남겨둠. 이 외의 불필요한 함수들 제거
  * getHyperCloudGroupModel()로 GroupModel노드 받아오는 구조로 리팩토링
* ReplicaSet 그룹 네모형태로 모양 변경