### PR TITLE
[feat][patch]메뉴얼 주소 수정

### DIFF
--- a/frontend/public/components/hypercloud/login/welcome.jsx
+++ b/frontend/public/components/hypercloud/login/welcome.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { withRouter } from 'react-router';
-
+import { HyperCloudManualLink } from '../../utils'
 const WelcomePage = ({ history }) => {
   localStorage.setItem('flag/first-time-login', true);
   return (
@@ -15,8 +15,8 @@ const WelcomePage = ({ history }) => {
         <p className="welcome__description">시작하기 위해 애플리케이션 용 네임스페이스를 만드세요.</p>
         <p className="welcome__description">
           자세한 내용은{' '}
-          <a href="https://technet.tmaxsoft.com/upload/download/online/hypercloud/pver-20200918-000001/4.1-ko/welcome/overview_sub/index.html" target="_blank">
-            HyperCloud 매뉴얼<i className="fas fa-external-link-alt"></i>
+          <a className='co-external-link' href={HyperCloudManualLink} target="_blank" rel="noopener noreferrer">
+            HyperCloud 매뉴얼
           </a>
           을 참조하세요.
         </p>

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -76,10 +76,6 @@ class MastheadToolbarContents_ extends React.Component {
     return formatNamespacedRouteForResource('import', this.props.activeNamespace);
   }
 
-  _getManualPath() {
-    return 'https://technet.tmaxsoft.com/upload/download/online/hypercloud/pver-20200918-000001/4.1-ko/welcome/overview_sub/index.html';
-  }
-
   _updateUser() {
     const { flags, user } = this.props;
     if (!flags[FLAGS.OPENSHIFT]) {
@@ -501,10 +497,9 @@ class MastheadToolbarContents_ extends React.Component {
             </ToolbarItem>
 
             <CloudShellMastheadButton />
-            {/* TODO: 매뉴얼 5.0버전으로 바꿔야함 */}
             <ToolbarItem className="co-masthead-icon__button">
               <Tooltip content="Manual" position={TooltipPosition.bottom}>
-                <a href="https://technet.tmaxsoft.com/upload/download/online/hypercloud/pver-20200918-000001/4.1-ko/welcome/overview_sub/index.html" target="_blank">
+                <a href={HyperCloudManualLink} target="_blank">
                 <QuestionCircleIcon className="co-masthead-icon" color="white"/></a>
               </Tooltip>
             </ToolbarItem>

--- a/frontend/public/components/start-guide.tsx
+++ b/frontend/public/components/start-guide.tsx
@@ -18,7 +18,8 @@ export const HypercloudGettingStarted = () => (
   <>
     <p>HyperCloud helps you quickly develop, host, and scale applications. To get started, you'll need a namespace. Currently, you can't create or access any namespaces. You'll need to contact a cluster administrator for help.</p>
     <p>
-      To learn more, visit the HyperCloud <HyperCloudManualLink href={'https://technet.tmaxsoft.com/upload/download/online/hypercloud/pver-20200918-000001/4.1-ko/welcome/overview_sub/index.html'} text="manual" />
+      To learn more, visit the HyperCloud   
+      <a className='co-external-link' href={HyperCloudManualLink} target="_blank" rel="noopener noreferrer" />
     </p>
   </>
 );

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -60,24 +60,14 @@ export const ExternalLink: React.FC<ExternalLinkProps> = ({ href, text, addition
     {text}
   </a>
 );
-export const HyperCloudManualLink: React.FC<HyperCloudManualLinkProps> = ({ href, text, additionalClassName = '', dataTestID }) => (
-  <a className={classNames('co-external-link', additionalClassName)} href={href} target="_blank" rel="noopener noreferrer" data-test-id={dataTestID}>
-    {text}
-  </a>
-);
+
+export const HyperCloudManualLink = "https://technet.tmaxsoft.com/upload/download/online/hypercloud/pver-20210701-000003/hypercloud/21-ko/user_guide/console_connect_sub/execution-environment.html";
 
 // Open links in a new window and set noopener/noreferrer.
 export const LinkifyExternal: React.FC<{ children: React.ReactNode }> = ({ children }) => <Linkify properties={{ target: '_blank', rel: 'noopener noreferrer' }}>{children}</Linkify>;
 LinkifyExternal.displayName = 'LinkifyExternal';
 
 type ExternalLinkProps = {
-  href: string;
-  text: React.ReactNode;
-  additionalClassName?: string;
-  dataTestID?: string;
-};
-
-type HyperCloudManualLinkProps = {
   href: string;
   text: React.ReactNode;
   additionalClassName?: string;


### PR DESCRIPTION
4버전 메뉴얼 주소 -> 5버전 메뉴얼 주소 (gs용으로 우선 적용)

GNB와 welcome 페이지에 각각 존재하던 링크들을 utils에서 관리하도록 수정. 
start-guide파일을 쓰고 있는 곳이 있어서 이전에 수정한 것인지 확인 요청. (없다면 아예 지워도 되는지)