### PR TITLE
[feat] Jest 버전 업그레이드, config파일분리, config 내용 수정

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -5,14 +5,7 @@
     "es6": true,
     "jasmine": true
   },
-  "extends": [
-    "eslint:recommended",
-    "plugin:import/errors",
-    "plugin:import/warnings",
-    "plugin:react/recommended",
-    "plugin:console/json",
-    "plugin:console/prettier"
-  ],
+  "extends": ["eslint:recommended", "plugin:import/errors", "plugin:import/warnings", "plugin:react/recommended", "plugin:console/json", "plugin:console/prettier"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": "./tsconfig.json",
@@ -27,10 +20,7 @@
   },
   "plugins": ["react", "react-hooks", "@typescript-eslint"],
   "rules": {
-    "camelcase": [
-      "error",
-      { "allow": ["UNSAFE_componentWillReceiveProps", "UNSAFE_componentWillMount"] }
-    ],
+    "camelcase": ["error", { "allow": ["UNSAFE_componentWillReceiveProps", "UNSAFE_componentWillMount"] }],
     "consistent-return": 0,
     "consistent-this": [1, "that"],
     "curly": [2, "all"],
@@ -53,10 +43,7 @@
     "no-prototype-builtins": 0, // Disable with exlint v6 update.
     "no-shadow": ["error"],
     "no-underscore-dangle": 0,
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      { "varsIgnorePattern": "React", "args": "after-used" }
-    ],
+    "@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "React", "args": "after-used" }],
     "@typescript-eslint/no-use-before-define": 2,
     "no-var": 2,
     "object-shorthand": ["error", "properties"],

--- a/frontend/before-tests.js
+++ b/frontend/before-tests.js
@@ -1,9 +1,10 @@
 /* eslint-env node */
+// MEMO : jest와 enzyme으로 테스트하던 기존 오픈쉬프트 js파일 (HyperCloud에선 사용하고 있지 않음)
 
-import { configure } from 'enzyme';
-import * as Adapter from 'enzyme-adapter-react-16';
+// import { configure } from 'enzyme';
+// import * as Adapter from 'enzyme-adapter-react-16';
 
-import 'url-search-params-polyfill';
+// import 'url-search-params-polyfill';
 
-// http://airbnb.io/enzyme/docs/installation/index.html#working-with-react-16
-configure({ adapter: new Adapter() });
+// // http://airbnb.io/enzyme/docs/installation/index.html#working-with-react-16
+// configure({ adapter: new Adapter() });

--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom';
+import 'url-search-params-polyfill';

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,30 @@
+// MEMO : jest에 enzyme으로 테스트하던 기존 오픈쉬프트 jest config. (HyperCloud에선 사용하고 있지 않음)
+
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jest-environment-jsdom',
+  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json'],
+  moduleNameMapper: {
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/fileMock.js',
+    '\\.(css|less|scss)$': '<rootDir>/__mocks__/styleMock.js',
+    '^dnd-core$': 'dnd-core/dist/cjs',
+    '^react-dnd$': 'react-dnd/dist/cjs',
+    '^react-dnd-html5-backend$': 'react-dnd-html5-backend/dist/cjs',
+  },
+  transform: {
+    '.(ts|tsx|js|jsx)': './node_modules/ts-jest/preprocessor.js',
+  },
+  transformIgnorePatterns: ['<rootDir>/node_modules/(?!(lodash-es|@console|@novnc|@spice-project)/.*)'],
+  testRegex: '.*\\.spec\\.(ts|tsx|js|jsx)$',
+  testURL: 'http://localhost',
+  setupFiles: ['./__mocks__/localStorage.ts', './__mocks__/matchMedia.js', './__mocks__/serverFlags.js', './__mocks__/mutationObserver.js'],
+  setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
+  coverageDirectory: '__coverage__',
+  coverageReporters: ['json', 'lcov', 'text', 'text-summary'],
+  collectCoverageFrom: ['public/*.{js,jsx,ts,tsx}', 'public/{components,module,ui}/**/*.{js,jsx,ts,tsx}', 'packages/*/src/**/*.{js,jsx,ts,tsx}', '!**/node_modules/**'],
+  globals: {
+    'ts-jest': {
+      isolatedModules: true,
+    },
+  },
+};

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,5 +1,3 @@
-// MEMO : jest에 enzyme으로 테스트하던 기존 오픈쉬프트 jest config. (HyperCloud에선 사용하고 있지 않음)
-
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jest-environment-jsdom',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,50 +32,6 @@
     "analyze": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode=production --profile --json | awk '{if(NR>2)print}' > public/dist/stats.json && ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack-bundle-analyzer --mode static -r public/dist/report.html public/dist/stats.json",
     "prettier-all": "prettier --write '**/*.{js,jsx,ts,tsx,json}'"
   },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "jsx",
-      "ts",
-      "tsx",
-      "json"
-    ],
-    "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-      "\\.(css|less|scss)$": "<rootDir>/__mocks__/styleMock.js",
-      "^dnd-core$": "dnd-core/dist/cjs",
-      "^react-dnd$": "react-dnd/dist/cjs",
-      "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs"
-    },
-    "transform": {
-      ".(ts|tsx|js|jsx)": "./node_modules/ts-jest/preprocessor.js"
-    },
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!(lodash-es|@console|@novnc|@spice-project)/.*)"
-    ],
-    "testRegex": ".*\\.spec\\.(ts|tsx|js|jsx)$",
-    "testURL": "http://localhost",
-    "setupFiles": [
-      "./__mocks__/localStorage.ts",
-      "./__mocks__/matchMedia.js",
-      "./__mocks__/serverFlags.js",
-      "./__mocks__/mutationObserver.js",
-      "./before-tests.js"
-    ],
-    "coverageDirectory": "__coverage__",
-    "coverageReporters": [
-      "json",
-      "lcov",
-      "text",
-      "text-summary"
-    ],
-    "collectCoverageFrom": [
-      "public/*.{js,jsx,ts,tsx}",
-      "public/{components,module,ui}/**/*.{js,jsx,ts,tsx}",
-      "packages/*/src/**/*.{js,jsx,ts,tsx}",
-      "!**/node_modules/**"
-    ]
-  },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.9.0",
     "@patternfly/patternfly": "2.71.5",
@@ -122,7 +78,6 @@
     "react-draggable": "4.x",
     "react-helmet": "^5.2.1",
     "react-hook-form": "^6.11.3",
-    "react-select": "^4.3.0",
     "react-i18next": "^11.7.3",
     "react-jsonschema-form": "1.7.0",
     "react-linkify": "^0.2.2",
@@ -133,6 +88,7 @@
     "react-redux": "7.1.0",
     "react-router": "5.0.1",
     "react-router-dom": "5.0.1",
+    "react-select": "^4.3.0",
     "react-tagsinput": "3.19.x",
     "react-transition-group": "2.3.x",
     "react-virtualized": "9.x",
@@ -154,13 +110,16 @@
   },
   "devDependencies": {
     "@hookform/devtools": "^2.2.1",
+    "@testing-library/dom": "^8.1.0",
+    "@testing-library/jest-dom": "^5.14.1",
+    "@testing-library/react": "^12.0.0",
     "@types/classnames": "^2.2.7",
     "@types/enzyme": "3.10.x",
     "@types/glob": "7.x",
     "@types/immutable": "3.x",
     "@types/jasmine": "2.8.x",
     "@types/jasminewd2": "2.0.x",
-    "@types/jest": "21.x",
+    "@types/jest": "^26.0.24",
     "@types/lodash-es": "4.x",
     "@types/node": "^9.6.52",
     "@types/prop-types": "15.5.6",
@@ -192,13 +151,13 @@
     "jasmine-console-reporter": "2.x",
     "jasmine-core": "2.x",
     "jasmine-reporters": "2.x",
-    "jest": "21.x",
-    "jest-cli": "21.x",
+    "jest": "^27.0.6",
+    "jest-cli": "^27.0.6",
     "mini-css-extract-plugin": "0.4.x",
     "moment": "2.22.x",
     "monaco-editor-core": "0.14.0",
     "monaco-editor-webpack-plugin": "^1.7.0",
-    "node-sass": "4.13.x",
+    "node-sass": "^6.0.1",
     "prettier": "1.19.1",
     "protractor": "5.4.x",
     "protractor-fail-fast": "3.x",
@@ -210,7 +169,7 @@
     "sass-loader": "6.x",
     "style-loader": "^0.23.1",
     "thread-loader": "1.x",
-    "ts-jest": "21.x",
+    "ts-jest": "^27.0.3",
     "ts-loader": "^6.2.2",
     "ts-node": "5.x",
     "typescript": "3.8.3",

--- a/frontend/packages/console-shared/src/components/formik-fields/__tests__/DropdownField.spec.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/__tests__/DropdownField.spec.tsx
@@ -14,7 +14,7 @@ jest.mock('formik', () => ({
 }));
 describe('DropdownField', () => {
   it('should pass through autocompleteFilter to Dropdown', () => {
-    const filterFn = jest.fn<React.ComponentProps<typeof DropdownField>['autocompleteFilter']>();
+    const filterFn = jest.fn();
     const wrapper = shallow(<DropdownField name="test" items={{}} autocompleteFilter={filterFn} />);
     expect(
       wrapper

--- a/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
@@ -146,7 +146,7 @@ describe('usePodScalingAccessStatus', () => {
   beforeEach(() => {
     jest
       .spyOn(utils, 'checkPodEditAccess')
-      .mockImplementation(() => Promise.resolve({ status: { allowed: false } }));
+      .mockImplementation(() => Promise.resolve({ status: { allowed: false },  apiVersion: 'authorization.k8s.io/v1', kind: 'SelfSubjectAccessReview', spec: {}  }));
     obj = {
       kind: '',
       metadata: {},

--- a/frontend/packages/console-shared/src/utils/__tests__/pod-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/pod-utils.spec.ts
@@ -1,20 +1,6 @@
 import * as utils from '@console/internal/components/utils';
-import {
-  isIdled,
-  isKnativeServing,
-  getPodStatus,
-  getPodData,
-  checkPodEditAccess,
-  isContainerLoopingFilter,
-} from '../pod-utils';
-import {
-  deploymentConfig,
-  notIdledDeploymentConfig,
-  deployment,
-  mockPod,
-  statefulSets,
-  allpods,
-} from '../__mocks__/pod-utils-test-data';
+import { isIdled, isKnativeServing, getPodStatus, getPodData, checkPodEditAccess, isContainerLoopingFilter } from '../pod-utils';
+import { deploymentConfig, notIdledDeploymentConfig, deployment, mockPod, statefulSets, allpods } from '../__mocks__/pod-utils-test-data';
 import { PodControllerOverviewItem } from '../../types';
 import { DeploymentConfigModel } from '@console/internal/models';
 import { K8sResourceKind } from '@console/internal/module/k8s';
@@ -115,24 +101,20 @@ describe('checkPodEditAccess', () => {
     };
   });
 
-  it('should have access true if check Access return allowed true', (done) => {
-    jest
-      .spyOn(utils, 'checkAccess')
-      .mockImplementation(() => Promise.resolve({ status: { allowed: true } }));
+  it('should have access true if check Access return allowed true', done => {
+    jest.spyOn(utils, 'checkAccess').mockImplementation(() => Promise.resolve({ status: { allowed: true }, apiVersion: 'authorization.k8s.io/v1', kind: 'SelfSubjectAccessReview', spec: {} }));
     checkPodEditAccess(obj, DeploymentConfigModel, undefined)
-      .then((resp) => {
+      .then(resp => {
         expect(resp.status.allowed).toBe(true);
         done();
       })
       .catch(() => {});
   });
 
-  it('should have access false if check Access return allowed false', (done) => {
-    jest
-      .spyOn(utils, 'checkAccess')
-      .mockImplementation(() => Promise.resolve({ status: { allowed: false } }));
+  it('should have access false if check Access return allowed false', done => {
+    jest.spyOn(utils, 'checkAccess').mockImplementation(() => Promise.resolve({ status: { allowed: false }, apiVersion: 'authorization.k8s.io/v1', kind: 'SelfSubjectAccessReview', spec: {} }));
     checkPodEditAccess(obj, DeploymentConfigModel, undefined)
-      .then((resp) => {
+      .then(resp => {
         expect(resp.status.allowed).toBe(false);
         done();
       })

--- a/frontend/packages/dev-console/src/components/import/__tests__/deployImage-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/deployImage-submit-utils.spec.ts
@@ -215,11 +215,11 @@ describe('DeployImage Submit Utils', () => {
 
       const imageStreamSpy = jest
         .spyOn(submitUtils, 'createOrUpdateImageStream')
-        .mockImplementation(() => ({
+        .mockImplementation(() => new Promise((resolve, reject) => resolve({
           status: {
             dockerImageReference: 'test:1234',
           },
-        }));
+        })));
 
       createOrUpdateDeployImageResources(mockData, false)
         .then((returnValue) => {

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
@@ -131,11 +131,11 @@ describe('Import Submit Utils', () => {
 
       const imageStreamSpy = jest
         .spyOn(submitUtils, 'createOrUpdateImageStream')
-        .mockImplementation(() => ({
+        .mockImplementation(() => new Promise((resolve, reject) => resolve({
           status: {
             dockerImageReference: 'test:1234',
           },
-        }));
+        })));
 
       const returnValue = await createOrUpdateResources(mockData, buildImage.obj, false);
       // createImageStream is called as separate entity

--- a/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPage.spec.tsx
@@ -17,7 +17,7 @@ let topologyProps: TopologyPageProps;
 let renderTopologyProps: RenderTopologyProps;
 
 jest.mock('react-redux', () => {
-  const ActualReactRedux = require.requireActual('react-redux');
+  const ActualReactRedux = jest.requireActual('react-redux');
   return {
     ...ActualReactRedux,
     useSelector: jest.fn(),

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -9,8 +9,8 @@ import { ingressValidHosts } from '../ingress';
 import { convertToBaseValue, EmptyBox, StatusBox, WithScrollContainer } from '../utils';
 import { getClusterOperatorStatus, getClusterOperatorVersion, getJobTypeAndCompletions, getTemplateInstanceStatus, K8sResourceKind, K8sResourceKindReference, NodeKind, planExternalName, PodKind, podPhase, podReadiness, podRestarts, serviceCatalogStatus, serviceClassDisplayName, MachineKind } from '../../module/k8s';
 //import LinkedPipelineRunTaskStatus from '../../../packages/dev-console/src/components/pipelineruns/status/LinkedPipelineRunTaskStatus';
-import { pipelineRunFilterReducer } from '../../../packages/dev-console/src/utils/pipeline-filter-reducer';
-import { pipelineRunDuration } from '../../../packages/dev-console/src/utils/pipeline-utils';
+import { pipelineRunFilterReducer } from '@console/dev-console/src/utils/pipeline-filter-reducer';
+import { pipelineRunDuration } from '@console/dev-console/src/utils/pipeline-utils';
 
 import {
   IRowData, // eslint-disable-line no-unused-vars


### PR DESCRIPTION
* jest 관련 라이브러리 및 ts-jest버전 업그레이드
* jest config파일을 jest.config.json으로 별도로 분리함
* @testing-library/react 와 @testing-library/jest-dom 라이브러리 추가 후 테스트코드에서 사용가능하도록 jest.config.json 내용 수정