### PR TITLE
[bugfix][patch][IMS]267885 [GS인증-21] 롤/클러스터 롤 액션버튼에서 수정

### DIFF
--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -50,7 +50,7 @@ const RolesTableRow = (t, { obj: role, index, key, style }) => {
       label: roleKind(role) === 'Role' ? t('COMMON:MSG_COMMON_ACTIONBUTTON_52') : t('COMMON:MSG_COMMON_ACTIONBUTTON_52'),
       href: `/k8s/cluster/rolebindings/~new?rolekind=${roleKind(role)}&rolename=${role.metadata.name}`,
     }),
-    Kebab.factory.Edit,
+    Kebab.factory.YAML,
     Kebab.factory.Delete,
   ];
   console.log(roleKind(role));
@@ -224,7 +224,7 @@ export const RolesDetailsPage = props => {
       label: t('COMMON:MSG_COMMON_ACTIONBUTTON_52'),
       href: `/k8s/cluster/rolebindings/~new?rolekind=${roleKind(role)}&rolename=${role.metadata.name}`,
     }),
-    Kebab.factory.Edit,
+    Kebab.factory.YAML,
     Kebab.factory.Delete,
   ];
   return <DetailsPage {...props} pages={[navFactory.details(withTranslation()(Details)), navFactory.editYaml(), { href: 'bindings', name: t('COMMON:MSG_DETAILS_TAB_14'), component: BindingsForRolePage }]} menuActions={menuActions} />;

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -363,6 +363,12 @@ const kebabFactory: KebabFactory = {
       accessReview: asAccessReview(kind, obj, 'patch'),
     };
   },
+  YAML: (kind, obj) => ({
+    label: `COMMON:MSG_MAIN_ACTIONBUTTON_15**${ResourceStringKeyMap[kind.kind]?.label ?? kind.label}`,
+    href: `${resourceObjPath(obj, kind.crd ? referenceForModel(kind) : kind.kind)}/yaml`,
+    // TODO: Fallback to "View YAML"? We might want a similar fallback for annotations, labels, etc.
+    accessReview: asAccessReview(kind, obj, 'update'),
+  }),
 };
 
 // The common menu actions that most resource share


### PR DESCRIPTION
[bugfix][patch][IMS]267885 [GS인증-21] 롤/클러스터 롤 액션버튼에서 수정
[배경] GS 인증에는 Role은 FORM edit 빼고 YAML만 추가했었음
[문제] 수정 action 버튼 클릭시 /edit 로 넘어가서 동작 안함
[해결] Kebab.factory.YAML 추가하고 Kebab.factory.Edit 에서 Kebab.factory.YAML 로 변경
