### PR TITLE
담당메뉴들 editYaml -> editResource 로 수정

### DIFF
--- a/frontend/__hypercloud_tests__/components/RadioGroup.spec.tsx
+++ b/frontend/__hypercloud_tests__/components/RadioGroup.spec.tsx
@@ -53,9 +53,9 @@ describe('RadioGroup Test', () => {
 
   it('items props로 받은 item들을 RadioInput아이템으로 렌더링 되어야 합니다.', () => {
     const { getByDisplayValue } = renderRadioGroupForm();
-    expect(getByDisplayValue('cpu')).toBeTruthy();
-    expect(getByDisplayValue('gpu')).toBeTruthy();
-    expect(getByDisplayValue('memory')).toBeTruthy();
+    getByDisplayValue('cpu');
+    getByDisplayValue('gpu');
+    getByDisplayValue('memory');
   });
 
   it('initValue로 설정한 input은 default로 체크 돼있어야 합니다.', () => {

--- a/frontend/__hypercloud_tests__/components/TagsLabel.spec.tsx
+++ b/frontend/__hypercloud_tests__/components/TagsLabel.spec.tsx
@@ -42,8 +42,8 @@ describe('TagsLabel Test', () => {
 
   it('form의 defaultValues로 기본 tag들이 생성돼야 합니다.', () => {
     const { container, getByText } = renderTagsLabelForm();
-    expect(getByText('AAA')).toBeTruthy();
-    expect(getByText('BBB')).toBeTruthy();
+    getByText('AAA');
+    getByText('BBB');
     expect(container).toMatchSnapshot();
   });
 
@@ -54,7 +54,7 @@ describe('TagsLabel Test', () => {
     userEvent.type(tagsInput, 'CCC');
     userEvent.keyboard('{Enter}');
     expect(tagsInput).toHaveValue('');
-    expect(getByText('CCC')).toBeTruthy();
+    getByText('CCC');
     expect(container).toMatchSnapshot();
   });
 

--- a/frontend/public/components/cluster-service-broker.tsx
+++ b/frontend/public/components/cluster-service-broker.tsx
@@ -124,7 +124,7 @@ const ClusterServiceBrokerDetails: React.SFC<ClusterServiceBrokerDetailsProps> =
 };
 
 const ServiceClassTabPage = ({ obj }) => <ClusterServiceClassPage showTitle={false} fieldSelector={`spec.clusterServiceBrokerName=${obj.metadata.name}`} />;
-export const ClusterServiceBrokerDetailsPage: React.SFC<ClusterServiceBrokerDetailsPageProps> = props => <DetailsPage {...props} kind={referenceForModel(ClusterServiceBrokerModel)} menuActions={menuActions} pages={[navFactory.details(detailsPage(ClusterServiceBrokerDetails)), navFactory.editYaml(), navFactory.clusterServiceClasses(ServiceClassTabPage)]} />;
+export const ClusterServiceBrokerDetailsPage: React.SFC<ClusterServiceBrokerDetailsPageProps> = props => <DetailsPage {...props} kind={referenceForModel(ClusterServiceBrokerModel)} menuActions={menuActions} pages={[navFactory.details(detailsPage(ClusterServiceBrokerDetails)), navFactory.editResource(), navFactory.clusterServiceClasses(ServiceClassTabPage)]} />;
 export const ClusterServiceBrokerList: React.SFC = props => <Table {...props} aria-label="Cluster Service Brokers" Header={ClusterServiceBrokerTableHeader} Row={ClusterServiceBrokerTableRow} virtualize />;
 
 export const ClusterServiceBrokerPage: React.SFC<ClusterServiceBrokerPageProps> = props => <ListPage {...props} ListComponent={ClusterServiceBrokerList} kind={referenceForModel(ClusterServiceBrokerModel)} canCreate={true} showTitle={false} />;

--- a/frontend/public/components/hypercloud/crd/create-pinned-resource.tsx
+++ b/frontend/public/components/hypercloud/crd/create-pinned-resource.tsx
@@ -2,30 +2,7 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import { JSONSchema6 } from 'json-schema';
 import { K8sKind, modelFor, K8sResourceKind, K8sResourceKindReference, kindForReference, referenceForModel } from '@console/internal/module/k8s';
-import {
-  CustomResourceDefinitionModel,
-  SecretModel,
-  TemplateModel,
-  ClusterTemplateModel,
-  AWXModel,
-  ClusterServiceBrokerModel,
-  FederatedConfigMapModel,
-  FederatedDeploymentModel,
-  FederatedHPAModel,
-  FederatedIngressModel,
-  FederatedJobModel,
-  FederatedNamespaceModel,
-  FederatedPodModel,
-  FederatedReplicaSetModel,
-  FederatedSecretModel,
-  FederatedCronJobModel,
-  FederatedDaemonSetModel,
-  FederatedServiceModel,
-  FederatedStatefulSetModel,
-  ServiceBindingModel,
-  NotebookModel,
-  ExperimentModel,
-} from '@console/internal/models';
+import * as models from '@console/internal/models';
 import { StatusBox, BreadCrumbs, resourcePathFromModel } from '@console/internal/components/utils';
 import { RootState } from '@console/internal/redux';
 import { SyncedEditor } from '@console/shared/src/components/synced-editor';
@@ -48,30 +25,30 @@ import { useTranslation } from 'react-i18next';
 // import { safeDump } from 'js-yaml';
 
 // MEMO : YAML Editor만 제공돼야 되는 리소스 kind
-// MEMO : Create, Edit 모두 YAML로 가능한 리소스만 editYaml -> editResource로 바꾸고 여기 kind 추가하기. 
+// MEMO : Create, Edit 모두 YAML로 가능한 리소스만 editYaml -> editResource로 바꾸고 여기 kind 추가하기.
 // MEMO : Create은 커스텀폼으로하고 디테일의 YAML탭에선 Read만 가능한 리소스의 경우엔 editYaml -> editResource로 수정하면 안됨.
 export const OnlyYamlEditorKinds = [
-  SecretModel.kind,
-  TemplateModel.kind,
-  ClusterTemplateModel.kind,
-  AWXModel.kind,
-  ClusterServiceBrokerModel.kind,
-  ServiceBindingModel.kind,
-  NotebookModel.kind,
-  ExperimentModel.kind,
-  FederatedConfigMapModel.kind,
-  FederatedDeploymentModel.kind,
-  FederatedHPAModel.kind,
-  FederatedIngressModel.kind,
-  FederatedJobModel.kind,
-  FederatedNamespaceModel.kind,
-  FederatedPodModel.kind,
-  FederatedReplicaSetModel.kind,
-  FederatedSecretModel.kind,
-  FederatedCronJobModel.kind,
-  FederatedDaemonSetModel.kind,
-  FederatedServiceModel.kind,
-  FederatedStatefulSetModel.kind,
+  models.SecretModel.kind,
+  models.TemplateModel.kind,
+  models.ClusterTemplateModel.kind,
+  models.AWXModel.kind,
+  models.ClusterServiceBrokerModel.kind,
+  models.ServiceBindingModel.kind,
+  models.NotebookModel.kind,
+  models.ExperimentModel.kind,
+  models.FederatedConfigMapModel.kind,
+  models.FederatedDeploymentModel.kind,
+  models.FederatedHPAModel.kind,
+  models.FederatedIngressModel.kind,
+  models.FederatedJobModel.kind,
+  models.FederatedNamespaceModel.kind,
+  models.FederatedPodModel.kind,
+  models.FederatedReplicaSetModel.kind,
+  models.FederatedSecretModel.kind,
+  models.FederatedCronJobModel.kind,
+  models.FederatedDaemonSetModel.kind,
+  models.FederatedServiceModel.kind,
+  models.FederatedStatefulSetModel.kind,
 ];
 
 export const CreateDefault: React.FC<CreateDefaultProps> = ({ initialEditorType, loadError, match, model, activePerspective, create }) => {
@@ -116,7 +93,7 @@ export const CreateDefault: React.FC<CreateDefaultProps> = ({ initialEditorType,
       const isCustomResourceType = !isResourceSchemaBasedMenuSet(kind);
       let url;
       if (isCustomResourceType) {
-        url = getK8sAPIPath({ apiGroup: CustomResourceDefinitionModel.apiGroup, apiVersion: CustomResourceDefinitionModel.apiVersion });
+        url = getK8sAPIPath({ apiGroup: models.CustomResourceDefinitionModel.apiGroup, apiVersion: models.CustomResourceDefinitionModel.apiVersion });
         url = `${document.location.origin}${url}/customresourcedefinitions/${model.plural}.${model.apiGroup}`;
       } else {
         const directory = kindToSchemaPath.get(model.kind)?.['directory'];

--- a/frontend/public/components/hypercloud/crd/create-pinned-resource.tsx
+++ b/frontend/public/components/hypercloud/crd/create-pinned-resource.tsx
@@ -2,7 +2,30 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import { JSONSchema6 } from 'json-schema';
 import { K8sKind, modelFor, K8sResourceKind, K8sResourceKindReference, kindForReference, referenceForModel } from '@console/internal/module/k8s';
-import { CustomResourceDefinitionModel, SecretModel, TemplateModel, ClusterTemplateModel, AWXModel } from '@console/internal/models';
+import {
+  CustomResourceDefinitionModel,
+  SecretModel,
+  TemplateModel,
+  ClusterTemplateModel,
+  AWXModel,
+  ClusterServiceBrokerModel,
+  FederatedConfigMapModel,
+  FederatedDeploymentModel,
+  FederatedHPAModel,
+  FederatedIngressModel,
+  FederatedJobModel,
+  FederatedNamespaceModel,
+  FederatedPodModel,
+  FederatedReplicaSetModel,
+  FederatedSecretModel,
+  FederatedCronJobModel,
+  FederatedDaemonSetModel,
+  FederatedServiceModel,
+  FederatedStatefulSetModel,
+  ServiceBindingModel,
+  NotebookModel,
+  ExperimentModel,
+} from '@console/internal/models';
 import { StatusBox, BreadCrumbs, resourcePathFromModel } from '@console/internal/components/utils';
 import { RootState } from '@console/internal/redux';
 import { SyncedEditor } from '@console/shared/src/components/synced-editor';
@@ -25,7 +48,31 @@ import { useTranslation } from 'react-i18next';
 // import { safeDump } from 'js-yaml';
 
 // MEMO : YAML Editor만 제공돼야 되는 리소스 kind
-const OnlyYamlEditorKinds = [SecretModel.kind, TemplateModel.kind, ClusterTemplateModel.kind, AWXModel.kind];
+// MEMO : Create, Edit 모두 YAML로 가능한 리소스만 editYaml -> editResource로 바꾸고 여기 kind 추가하기. 
+// MEMO : Create은 커스텀폼으로하고 디테일의 YAML탭에선 Read만 가능한 리소스의 경우엔 editYaml -> editResource로 수정하면 안됨.
+export const OnlyYamlEditorKinds = [
+  SecretModel.kind,
+  TemplateModel.kind,
+  ClusterTemplateModel.kind,
+  AWXModel.kind,
+  ClusterServiceBrokerModel.kind,
+  ServiceBindingModel.kind,
+  NotebookModel.kind,
+  ExperimentModel.kind,
+  FederatedConfigMapModel.kind,
+  FederatedDeploymentModel.kind,
+  FederatedHPAModel.kind,
+  FederatedIngressModel.kind,
+  FederatedJobModel.kind,
+  FederatedNamespaceModel.kind,
+  FederatedPodModel.kind,
+  FederatedReplicaSetModel.kind,
+  FederatedSecretModel.kind,
+  FederatedCronJobModel.kind,
+  FederatedDaemonSetModel.kind,
+  FederatedServiceModel.kind,
+  FederatedStatefulSetModel.kind,
+];
 
 export const CreateDefault: React.FC<CreateDefaultProps> = ({ initialEditorType, loadError, match, model, activePerspective, create }) => {
   const { t } = useTranslation();

--- a/frontend/public/components/hypercloud/crd/edit-resource.tsx
+++ b/frontend/public/components/hypercloud/crd/edit-resource.tsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import { JSONSchema6 } from 'json-schema';
 import { K8sKind, modelFor, K8sResourceKind, K8sResourceKindReference, referenceForModel } from '@console/internal/module/k8s';
-import { CustomResourceDefinitionModel, SecretModel, TemplateModel, ClusterTemplateModel, AWXModel } from '@console/internal/models';
+import { CustomResourceDefinitionModel } from '@console/internal/models';
 import { StatusBox, resourcePathFromModel } from '@console/internal/components/utils';
 import { RootState } from '@console/internal/redux';
 import { SyncedEditor } from '@console/shared/src/components/synced-editor';
@@ -21,8 +21,7 @@ import { getIdToken } from '../../../hypercloud/auth';
 import { getK8sAPIPath } from '@console/internal/module/k8s/resource.js';
 import { AsyncComponent } from '../../utils/async';
 import { isSaveButtonDisabled } from '../utils/button-state';
-// MEMO : YAML Editor만 제공돼야 되는 리소스 kind
-const OnlyYamlEditorKinds = [SecretModel.kind, TemplateModel.kind, ClusterTemplateModel.kind, AWXModel.kind];
+import { OnlyYamlEditorKinds } from './create-pinned-resource';
 
 export const EditDefault: React.FC<EditDefaultProps> = ({ initialEditorType, loadError, match, model, activePerspective, obj, create }) => {
   if (!model) {

--- a/frontend/public/components/hypercloud/experiment.tsx
+++ b/frontend/public/components/hypercloud/experiment.tsx
@@ -165,7 +165,7 @@ const ExperimentDetails: React.FC<ExperimentDetailsProps> = ({ obj: experiment }
   );
 };
 
-const { details, editYaml } = navFactory;
+const { details, editResource } = navFactory;
 export const Experiments: React.FC = props => {
   const { t } = useTranslation();
   return <Table {...props} aria-label="Experiments" Header={ExperimentTableHeader.bind(null, t)} Row={ExperimentTableRow} virtualize />;
@@ -173,7 +173,7 @@ export const Experiments: React.FC = props => {
 
 export const ExperimentsPage: React.FC<ExperimentsPageProps> = props => <ListPage canCreate={true} ListComponent={Experiments} kind={kind} {...props} />;
 
-export const ExperimentsDetailsPage: React.FC<ExperimentsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(ExperimentDetails)), editYaml()]} />;
+export const ExperimentsDetailsPage: React.FC<ExperimentsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(ExperimentDetails)), editResource()]} />;
 
 type ExperimentDetailsListProps = {
   experiment: K8sResourceKind;

--- a/frontend/public/components/hypercloud/federated-config-map.tsx
+++ b/frontend/public/components/hypercloud/federated-config-map.tsx
@@ -117,7 +117,7 @@ const FederatedConfigMapDetails: React.FC<FederatedConfigMapDetailsProps> = ({ o
   );
 };
 
-const { details, editYaml, events } = navFactory;
+const { details, editResource, events } = navFactory;
 export const FederatedConfigMaps: React.FC = props => {
   const { t } = useTranslation();
   return <Table {...props} aria-label="Federated Config Maps" Header={FederatedConfigMapTableHeader.bind(null, t)} Row={FederatedConfigMapTableRow} virtualize />;
@@ -125,7 +125,7 @@ export const FederatedConfigMaps: React.FC = props => {
 
 export const FederatedConfigMapsPage: React.FC<FederatedConfigMapsPageProps> = props => <ListPage canCreate={true} ListComponent={FederatedConfigMaps} kind={kind} {...props} />;
 
-export const FederatedConfigMapsDetailsPage: React.FC<FederatedConfigMapsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedConfigMapDetails)), editYaml(), events(ResourceEventStream)]} />;
+export const FederatedConfigMapsDetailsPage: React.FC<FederatedConfigMapsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedConfigMapDetails)), editResource(), events(ResourceEventStream)]} />;
 
 type FederatedConfigMapDetailsListProps = {
   ds: K8sResourceKind;

--- a/frontend/public/components/hypercloud/federated-cronjob.tsx
+++ b/frontend/public/components/hypercloud/federated-cronjob.tsx
@@ -140,14 +140,14 @@ const FederatedCronJobDetails: React.FC<FederatedCronJobDetailsProps> = ({ obj: 
   );
 };
 
-const { details, editYaml } = navFactory;
+const { details, editResource } = navFactory;
 export const FederatedCronJobs: React.FC = props => {
   const { t } = useTranslation();
   return <Table {...props} aria-label="Federated Cron Jobs" Header={FederatedCronJobTableHeader.bind(null, t)} Row={FederatedCronJobTableRow} virtualize />;
 };
 export const FederatedCronJobsPage: React.FC<FederatedCronJobsPageProps> = props => <ListPage canCreate={true} ListComponent={FederatedCronJobs} kind={kind} {...props} />;
 
-export const FederatedCronJobsDetailsPage: React.FC<FederatedCronJobsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedCronJobDetails)), editYaml()]} />;
+export const FederatedCronJobsDetailsPage: React.FC<FederatedCronJobsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedCronJobDetails)), editResource()]} />;
 
 type ClusterRowProps = {
   cronjob: K8sResourceKind;

--- a/frontend/public/components/hypercloud/federated-daemonset.tsx
+++ b/frontend/public/components/hypercloud/federated-daemonset.tsx
@@ -140,7 +140,7 @@ const FederatedDaemonSetDetails: React.FC<FederatedDaemonSetDetailsProps> = ({ o
   );
 };
 
-const { details, editYaml } = navFactory;
+const { details, editResource } = navFactory;
 export const FederatedDaemonSets: React.FC = props => {
   const { t } = useTranslation();
   return <Table {...props} aria-label="Federated Daemon Sets" Header={FederatedDaemonSetTableHeader.bind(null, t)} Row={FederatedDaemonSetTableRow} virtualize />;
@@ -148,7 +148,7 @@ export const FederatedDaemonSets: React.FC = props => {
 
 export const FederatedDaemonSetsPage: React.FC<FederatedDaemonSetsPageProps> = props => <ListPage canCreate={true} ListComponent={FederatedDaemonSets} kind={kind} {...props} />;
 
-export const FederatedDaemonSetsDetailsPage: React.FC<FederatedDaemonSetsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedDaemonSetDetails)), editYaml()]} />;
+export const FederatedDaemonSetsDetailsPage: React.FC<FederatedDaemonSetsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedDaemonSetDetails)), editResource()]} />;
 
 type ClusterRowProps = {
   daemonset: K8sResourceKind;

--- a/frontend/public/components/hypercloud/federated-deployment.tsx
+++ b/frontend/public/components/hypercloud/federated-deployment.tsx
@@ -89,7 +89,7 @@ const FederatedDeploymentDetails: React.FC<FederatedDeploymentDetailsProps> = ({
   );
 };
 
-const { details, editYaml, events } = navFactory;
+const { details, editResource, events } = navFactory;
 export const FederatedDeployments: React.FC = props => {
   const { t } = useTranslation();
   return <Table {...props} aria-label="Federated Deployments" Header={FederatedDeploymentTableHeader.bind(null, t)} Row={FederatedDeploymentTableRow} virtualize />;
@@ -97,7 +97,7 @@ export const FederatedDeployments: React.FC = props => {
 
 export const FederatedDeploymentsPage: React.FC<FederatedDeploymentsPageProps> = props => <ListPage canCreate={true} ListComponent={FederatedDeployments} kind={kind} {...props} />;
 
-export const FederatedDeploymentsDetailsPage: React.FC<FederatedDeploymentsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedDeploymentDetails)), editYaml(), events(ResourceEventStream)]} />;
+export const FederatedDeploymentsDetailsPage: React.FC<FederatedDeploymentsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedDeploymentDetails)), editResource(), events(ResourceEventStream)]} />;
 
 type FederatedDeploymentDetailsProps = {
   obj: K8sResourceKind;

--- a/frontend/public/components/hypercloud/federated-horizontalpodautoscaler.tsx
+++ b/frontend/public/components/hypercloud/federated-horizontalpodautoscaler.tsx
@@ -132,12 +132,12 @@ const FederatedHPADetails: React.FC<FederatedHPADetailsProps> = ({ obj: horizont
   </>
 );
 
-const { details, editYaml } = navFactory;
+const { details, editResource } = navFactory;
 export const FederatedHPAs: React.FC = props => <Table {...props} aria-label="Federated HPAs" Header={FederatedHPATableHeader} Row={FederatedHPATableRow} virtualize />;
 
 export const FederatedHPAsPage: React.FC<FederatedHPAsPageProps> = props => <ListPage canCreate={true} ListComponent={FederatedHPAs} kind={kind} {...props} />;
 
-export const FederatedHPAsDetailsPage: React.FC<FederatedHPAsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedHPADetails)), editYaml()]} />;
+export const FederatedHPAsDetailsPage: React.FC<FederatedHPAsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedHPADetails)), editResource()]} />;
 
 type ClusterRowProps = {
   horizontalpodautoscaler: K8sResourceKind;

--- a/frontend/public/components/hypercloud/federated-ingress.tsx
+++ b/frontend/public/components/hypercloud/federated-ingress.tsx
@@ -109,12 +109,12 @@ const FederatedIngressDetails: React.FC<FederatedIngressDetailsProps> = ({ obj: 
   </>
 );
 
-const { details, editYaml, events } = navFactory;
+const { details, editResource, events } = navFactory;
 export const FederatedIngresses: React.FC = props => <Table {...props} aria-label="Federated Ingresses" Header={FederatedIngressTableHeader} Row={FederatedIngressTableRow} virtualize />;
 
 export const FederatedIngressesPage: React.FC<FederatedIngressesPageProps> = props => <ListPage canCreate={true} ListComponent={FederatedIngresses} kind={kind} {...props} />;
 
-export const FederatedIngressesDetailsPage: React.FC<FederatedIngressesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedIngressDetails)), editYaml(), events(ResourceEventStream)]} />;
+export const FederatedIngressesDetailsPage: React.FC<FederatedIngressesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedIngressDetails)), editResource(), events(ResourceEventStream)]} />;
 
 type FederatedIngressDetailsListProps = {
   ds: K8sResourceKind;

--- a/frontend/public/components/hypercloud/federated-job.tsx
+++ b/frontend/public/components/hypercloud/federated-job.tsx
@@ -117,7 +117,7 @@ const FederatedJobDetails: React.FC<FederatedJobDetailsProps> = ({ obj: job }) =
   );
 };
 
-const { details, editYaml, events } = navFactory;
+const { details, editResource, events } = navFactory;
 export const FederatedJobs: React.FC = props => {
   const { t } = useTranslation();
   return <Table {...props} aria-label="Federated Jobs" Header={FederatedJobTableHeader.bind(null, t)} Row={FederatedJobTableRow} virtualize />;
@@ -125,7 +125,7 @@ export const FederatedJobs: React.FC = props => {
 
 export const FederatedJobsPage: React.FC<FederatedJobsPageProps> = props => <ListPage canCreate={true} ListComponent={FederatedJobs} kind={kind} {...props} />;
 
-export const FederatedJobsDetailsPage: React.FC<FederatedJobsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedJobDetails)), editYaml(), events(ResourceEventStream)]} />;
+export const FederatedJobsDetailsPage: React.FC<FederatedJobsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedJobDetails)), editResource(), events(ResourceEventStream)]} />;
 
 type FederatedJobDetailsListProps = {
   ds: K8sResourceKind;

--- a/frontend/public/components/hypercloud/federated-namespace.tsx
+++ b/frontend/public/components/hypercloud/federated-namespace.tsx
@@ -75,12 +75,12 @@ const FederatedNamespaceDetails: React.FC<FederatedNamespaceDetailsProps> = ({ o
   </>
 );
 
-const { details, editYaml, events } = navFactory;
+const { details, editResource, events } = navFactory;
 export const FederatedNamespaces: React.FC = props => <Table {...props} aria-label="Federated Namespaces" Header={FederatedNamespaceTableHeader} Row={FederatedNamespaceTableRow} virtualize />;
 
 export const FederatedNamespacesPage: React.FC<FederatedNamespacesPageProps> = props => <ListPage canCreate={true} ListComponent={FederatedNamespaces} kind={kind} {...props} />;
 
-export const FederatedNamespacesDetailsPage: React.FC<FederatedNamespacesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedNamespaceDetails)), editYaml(), events(ResourceEventStream)]} />;
+export const FederatedNamespacesDetailsPage: React.FC<FederatedNamespacesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedNamespaceDetails)), editResource(), events(ResourceEventStream)]} />;
 
 type FederatedNamespaceDetailsProps = {
   obj: K8sResourceKind;

--- a/frontend/public/components/hypercloud/federated-pod.tsx
+++ b/frontend/public/components/hypercloud/federated-pod.tsx
@@ -140,7 +140,7 @@ const FederatedPodDetails: React.FC<FederatedPodDetailsProps> = ({ obj: pod }) =
   );
 };
 
-const { details, editYaml } = navFactory;
+const { details, editResource } = navFactory;
 export const FederatedPods: React.FC = props => {
   const { t } = useTranslation();
   return <Table {...props} aria-label="Federated Pods" Header={FederatedPodTableHeader.bind(null, t)} Row={FederatedPodTableRow} virtualize />;
@@ -148,7 +148,7 @@ export const FederatedPods: React.FC = props => {
 
 export const FederatedPodsPage: React.FC<FederatedPodsPageProps> = props => <ListPage canCreate={true} ListComponent={FederatedPods} kind={kind} {...props} />;
 
-export const FederatedPodsDetailsPage: React.FC<FederatedPodsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedPodDetails)), editYaml()]} />;
+export const FederatedPodsDetailsPage: React.FC<FederatedPodsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedPodDetails)), editResource()]} />;
 
 type ClusterRowProps = {
   pod: K8sResourceKind;

--- a/frontend/public/components/hypercloud/federated-replica-set.tsx
+++ b/frontend/public/components/hypercloud/federated-replica-set.tsx
@@ -117,7 +117,7 @@ const FederatedReplicaSetDetails: React.FC<FederatedReplicaSetDetailsProps> = ({
   );
 };
 
-const { details, editYaml, events } = navFactory;
+const { details, editResource, events } = navFactory;
 export const FederatedReplicaSets: React.FC = props => {
   const { t } = useTranslation();
   return <Table {...props} aria-label="Federated Replica Sets" Header={FederatedReplicaSetTableHeader.bind(null, t)} Row={FederatedReplicaSetTableRow} virtualize />;
@@ -125,7 +125,7 @@ export const FederatedReplicaSets: React.FC = props => {
 
 export const FederatedReplicaSetsPage: React.FC<FederatedReplicaSetsPageProps> = props => <ListPage canCreate={true} ListComponent={FederatedReplicaSets} kind={kind} {...props} />;
 
-export const FederatedReplicaSetsDetailsPage: React.FC<FederatedReplicaSetsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedReplicaSetDetails)), editYaml(), events(ResourceEventStream)]} />;
+export const FederatedReplicaSetsDetailsPage: React.FC<FederatedReplicaSetsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedReplicaSetDetails)), editResource(), events(ResourceEventStream)]} />;
 
 type FederatedReplicaSetDetailsListProps = {
   ds: K8sResourceKind;

--- a/frontend/public/components/hypercloud/federated-secret.tsx
+++ b/frontend/public/components/hypercloud/federated-secret.tsx
@@ -117,7 +117,7 @@ const FederatedSecretDetails: React.FC<FederatedSecretDetailsProps> = ({ obj: se
   );
 };
 
-const { details, editYaml, events } = navFactory;
+const { details, editResource, events } = navFactory;
 export const FederatedSecrets: React.FC = props => {
   const { t } = useTranslation();
   return <Table {...props} aria-label="Federated Secrets" Header={FederatedSecretTableHeader.bind(null, t)} Row={FederatedSecretTableRow} virtualize />;
@@ -125,7 +125,7 @@ export const FederatedSecrets: React.FC = props => {
 
 export const FederatedSecretsPage: React.FC<FederatedSecretsPageProps> = props => <ListPage canCreate={true} ListComponent={FederatedSecrets} kind={kind} {...props} />;
 
-export const FederatedSecretsDetailsPage: React.FC<FederatedSecretsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedSecretDetails)), editYaml(), events(ResourceEventStream)]} />;
+export const FederatedSecretsDetailsPage: React.FC<FederatedSecretsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedSecretDetails)), editResource(), events(ResourceEventStream)]} />;
 
 type FederatedSecretDetailsListProps = {
   ds: K8sResourceKind;

--- a/frontend/public/components/hypercloud/federated-service.tsx
+++ b/frontend/public/components/hypercloud/federated-service.tsx
@@ -189,12 +189,12 @@ const FederatedServiceDetails: React.FC<FederatedServiceDetailsProps> = ({ obj: 
   </>
 );
 
-const { details, editYaml, events } = navFactory;
+const { details, editResource, events } = navFactory;
 export const FederatedServices: React.FC = props => <Table {...props} aria-label="Federated Services" Header={FederatedServiceTableHeader} Row={FederatedServiceTableRow} virtualize />;
 
 export const FederatedServicesPage: React.FC<FederatedServicesPageProps> = props => <ListPage canCreate={true} ListComponent={FederatedServices} kind={kind} {...props} />;
 
-export const FederatedServicesDetailsPage: React.FC<FederatedServicesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedServiceDetails)), editYaml(), events(ResourceEventStream)]} />;
+export const FederatedServicesDetailsPage: React.FC<FederatedServicesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedServiceDetails)), editResource(), events(ResourceEventStream)]} />;
 
 type FederatedServiceDetailsProps = {
   obj: K8sResourceKind;

--- a/frontend/public/components/hypercloud/federated-statefulset.tsx
+++ b/frontend/public/components/hypercloud/federated-statefulset.tsx
@@ -140,14 +140,14 @@ const FederatedStatefulSetDetails: React.FC<FederatedStatefulSetDetailsProps> = 
   );
 };
 
-const { details, editYaml } = navFactory;
+const { details, editResource } = navFactory;
 export const FederatedStatefulSets: React.FC = props => {
   const { t } = useTranslation();
   return <Table {...props} aria-label="Federated Stateful Sets" Header={FederatedStatefulSetTableHeader.bind(null, t)} Row={FederatedStatefulSetTableRow} virtualize />;
 };
 export const FederatedStatefulSetsPage: React.FC<FederatedStatefulSetsPageProps> = props => <ListPage canCreate={true} ListComponent={FederatedStatefulSets} kind={kind} {...props} />;
 
-export const FederatedStatefulSetsDetailsPage: React.FC<FederatedStatefulSetsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedStatefulSetDetails)), editYaml()]} />;
+export const FederatedStatefulSetsDetailsPage: React.FC<FederatedStatefulSetsDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(FederatedStatefulSetDetails)), editResource()]} />;
 
 type ClusterRowProps = {
   statefulset: K8sResourceKind;

--- a/frontend/public/components/hypercloud/notebook.tsx
+++ b/frontend/public/components/hypercloud/notebook.tsx
@@ -105,7 +105,7 @@ const NotebookDetails: React.FC<NotebookDetailsProps> = ({ obj: notebook }) => {
   );
 };
 
-const { details, editYaml } = navFactory;
+const { details, editResource } = navFactory;
 export const Notebooks: React.FC = props => {
   const { t } = useTranslation();
   return <Table {...props} aria-label="Notebooks" Header={NotebookTableHeader.bind(null, t)} Row={NotebookTableRow} virtualize />;
@@ -115,7 +115,7 @@ export const NotebooksPage: React.FC<NotebooksPageProps> = props => <ListPage ca
 
 export const NotebooksDetailsPage: React.FC<DetailsPageProps> = props => {
   const url = props?.namespace && props?.name ? `/api/kubeflow/${id}/${props.namespace}/${props.name}/` : null;
-  return <DetailsPage {...props} kind={kind} menuActions={menuActions} customData={{ label: 'Connect', url }} pages={[details(detailsPage(NotebookDetails)), editYaml()]} />
+  return <DetailsPage {...props} kind={kind} menuActions={menuActions} customData={{ label: 'Connect', url }} pages={[details(detailsPage(NotebookDetails)), editResource()]} />
 };
 
 type NotebookDetailsListProps = {

--- a/frontend/public/components/hypercloud/service-instance.tsx
+++ b/frontend/public/components/hypercloud/service-instance.tsx
@@ -10,7 +10,7 @@ import { K8sResourceKind, modelFor, k8sGet } from '../../module/k8s';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
 import { DetailsPage, ListPage, Table, TableData, TableRow } from '../factory';
-import { Kebab, ResourceKebab, navFactory, SectionHeading, ResourceSummary, ResourceLink, Timestamp, resourcePath } from '../utils';
+import { Kebab, ResourceKebab, navFactory, viewYamlComponent, SectionHeading, ResourceSummary, ResourceLink, Timestamp, resourcePath } from '../utils';
 import { ResourceSidebar } from '../sidebars/resource-sidebar';
 import { ResourceLabel } from '../../models/hypercloud/resource-plural';
 import { ResourceIcon } from '../utils/resource-icon';
@@ -119,7 +119,7 @@ type ServiceInstanceDetailsProps = {
 };
 
 const { details, editYaml } = navFactory;
-const ServiceInstancesDetailsPage: React.FC<ServiceInstancesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={serviceInstanceMenuActions} getResourceStatus={serviceInstanceStatusReducer} pages={[details(ServiceInstanceDetails), editYaml()]} />;
+const ServiceInstancesDetailsPage: React.FC<ServiceInstancesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={serviceInstanceMenuActions} getResourceStatus={serviceInstanceStatusReducer} pages={[details(ServiceInstanceDetails), editYaml(viewYamlComponent)]} />;
 ServiceInstancesDetailsPage.displayName = 'ServiceInstancesDetailsPage';
 
 const tableColumnClasses = [

--- a/frontend/public/components/service-binding.tsx
+++ b/frontend/public/components/service-binding.tsx
@@ -98,7 +98,7 @@ const ServiceBindingDetails: React.SFC<ServiceBindingDetailsProps> = ({ obj: sb 
 
 const pages = [
   navFactory.details(ServiceBindingDetails),
-  navFactory.editYaml(),
+  navFactory.editResource(),
   navFactory.events(ResourceEventStream),
 ];
 export const ServiceBindingDetailsPage: React.SFC<ServiceBindingDetailsPageProps> = (props) => (


### PR DESCRIPTION
* 테스트코드 불필요한 toBeTruthy체크 제거
*  (create-pinned-resource.tsx, edit-resource.tsx 각각 있었던) OnlyYamlEditorKinds 배열 한 곳으로 합침
*  ServiceCatalog, Federation 하위 메뉴들과 Notebook, Experiment 메뉴 디테일 editYaml -> editResource 로 수정 후 OnlyYamlEditorKinds 에 kind 추가함
* ServiceInstance의 경우 생성은 폼으로, 수정은 불가해서 YAML read만 가능한 리소스라 editYaml을 readOnly로 제공하도록 수정함