### PR TITLE
[refactor] 담당 메뉴에 대해 no status 처리 및 table-filter 리팩토링 &  IMS 269431 - HPA yaml view 예제 api 버전 수정

### DIFF
--- a/frontend/packages/dev-console/src/utils/hc-status-reducers.ts
+++ b/frontend/packages/dev-console/src/utils/hc-status-reducers.ts
@@ -41,13 +41,9 @@ export const ClusterServiceBrokerReducer = instance => {
   }
 };
 
-export const ServiceInstanceStatusReducer = (serviceInstance: any): string => {
-  return !!serviceInstance.status ? serviceInstance.status.lastConditionState : NO_STATUS;
-};
+export const ServiceInstanceStatusReducer = (serviceInstance: any): string => baseStatusReducer('status', 'lastConditionState')(serviceInstance);
 
-export const ClusterTemplateClaimReducer = (clusterTemplateClaim: any): string => {
-  return !!clusterTemplateClaim.status ? clusterTemplateClaim.status.status : NO_STATUS;
-};
+export const ClusterTemplateClaimReducer = (clusterTemplateClaim: any): string => baseStatusReducer('status', 'status')(clusterTemplateClaim);
 
 export const TemplateInstanceStatusReducer = instance => {
   let phase = '';
@@ -76,9 +72,7 @@ export const ExperimentStatusReducer = experiment => {
   }
 };
 
-export const ClusterClaimStatusReducer = (clusterClaim: any): string => {
-  return !!clusterClaim.status ? clusterClaim.status.phase : NO_STATUS;
-};
+export const ClusterClaimStatusReducer = (clusterClaim: any): string => baseStatusReducer('status', 'phase')(clusterClaim);
 
 export const awxStatusReducer = (awx: any): string => {
   if (!awx.status) return NO_STATUS;

--- a/frontend/packages/dev-console/src/utils/hc-status-reducers.ts
+++ b/frontend/packages/dev-console/src/utils/hc-status-reducers.ts
@@ -1,4 +1,9 @@
 import { NO_STATUS } from '@console/shared/src/components/status';
+import * as _ from 'lodash-es';
+
+export const baseStatusReducer = (depth1: string, depth2: string) => (obj: any): string => {
+  return !!obj[depth1] ? obj[depth1][depth2] : NO_STATUS;
+};
 
 export const ServiceBrokerStatusReducer = instance => {
   let phase = '';
@@ -73,4 +78,11 @@ export const ExperimentStatusReducer = experiment => {
 
 export const ClusterClaimStatusReducer = (clusterClaim: any): string => {
   return !!clusterClaim.status ? clusterClaim.status.phase : NO_STATUS;
+};
+
+export const awxStatusReducer = (awx: any): string => {
+  if (!awx.status) return NO_STATUS;
+  const conditions = _.get(awx, ['status', 'conditions'], []);
+  if (conditions.length === 0) return '-';
+  return conditions[0].reason === 'Successful' ? 'Succeeded' : conditions[0].reason === 'Running' ? 'Deploying' : conditions[0].reason;
 };

--- a/frontend/packages/dev-console/src/utils/hc-status-reducers.ts
+++ b/frontend/packages/dev-console/src/utils/hc-status-reducers.ts
@@ -1,10 +1,6 @@
 import { NO_STATUS } from '@console/shared/src/components/status';
 import * as _ from 'lodash-es';
 
-export const baseStatusReducer = (depth1: string, depth2: string) => (obj: any): string => {
-  return !!obj[depth1] ? obj[depth1][depth2] : NO_STATUS;
-};
-
 export const ServiceBrokerStatusReducer = instance => {
   let phase = '';
   if (instance.status) {
@@ -41,9 +37,13 @@ export const ClusterServiceBrokerReducer = instance => {
   }
 };
 
-export const ServiceInstanceStatusReducer = (serviceInstance: any): string => baseStatusReducer('status', 'lastConditionState')(serviceInstance);
+export const ServiceInstanceStatusReducer = (serviceInstance: any): string => {
+  return !!serviceInstance.status ? serviceInstance.status.lastConditionState : NO_STATUS;
+};
 
-export const ClusterTemplateClaimReducer = (clusterTemplateClaim: any): string => baseStatusReducer('status', 'status')(clusterTemplateClaim);
+export const ClusterTemplateClaimReducer = (clusterTemplateClaim: any): string => {
+  return !!clusterTemplateClaim.status ? clusterTemplateClaim.status.status : NO_STATUS;
+};
 
 export const TemplateInstanceStatusReducer = instance => {
   let phase = '';
@@ -72,11 +72,19 @@ export const ExperimentStatusReducer = experiment => {
   }
 };
 
-export const ClusterClaimStatusReducer = (clusterClaim: any): string => baseStatusReducer('status', 'phase')(clusterClaim);
+export const ClusterClaimStatusReducer = (clusterClaim: any): string => {
+  return !!clusterClaim.status ? clusterClaim.status.phase : NO_STATUS;
+};
 
-export const awxStatusReducer = (awx: any): string => {
-  if (!awx.status) return NO_STATUS;
+export const AwxStatusReducer = (awx: any): string => {
+  if (!awx.status) {
+    return NO_STATUS;
+  }
   const conditions = _.get(awx, ['status', 'conditions'], []);
   if (conditions.length === 0) return '-';
   return conditions[0].reason === 'Successful' ? 'Succeeded' : conditions[0].reason === 'Running' ? 'Deploying' : conditions[0].reason;
+};
+
+export const NamespaceClaimReducer = (namespaceClaim: any): string => {
+  return !!namespaceClaim.status ? namespaceClaim.status.status : NO_STATUS;
 };

--- a/frontend/packages/dev-console/src/utils/hc-status-reducers.ts
+++ b/frontend/packages/dev-console/src/utils/hc-status-reducers.ts
@@ -81,7 +81,9 @@ export const AwxStatusReducer = (awx: any): string => {
     return NO_STATUS;
   }
   const conditions = _.get(awx, ['status', 'conditions'], []);
-  if (conditions.length === 0) return '-';
+  if (conditions.length === 0) {
+    return '-';
+  }
   return conditions[0].reason === 'Successful' ? 'Succeeded' : conditions[0].reason === 'Running' ? 'Deploying' : conditions[0].reason;
 };
 

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Status, PodRingController } from '@console/shared';
+import { Status, PodRingController, NO_STATUS } from '@console/shared';
 import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
 import { DeploymentModel } from '../models';
@@ -77,6 +77,11 @@ export const DeploymentDetailsList: React.FC<DeploymentDetailsListProps> = ({ de
 };
 DeploymentDetailsList.displayName = 'DeploymentDetailsList';
 
+const deploymentStatusReducer = (deployment: any): string => {
+  if (!deployment.status) return NO_STATUS;
+  return deployment.status.availableReplicas === deployment.status.updatedReplicas && deployment.spec.replicas === deployment.status.availableReplicas ? 'Up to date' : 'Updating';
+};
+
 const DeploymentDetails: React.FC<DeploymentDetailsProps> = ({ obj: deployment }) => {
   const { t } = useTranslation();
   return (
@@ -96,7 +101,9 @@ const DeploymentDetails: React.FC<DeploymentDetailsProps> = ({ obj: deployment }
             <div className="col-sm-6">
               <ResourceSummary resource={deployment} showPodSelector showNodeSelector showTolerations>
                 <dt>{t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_13')}</dt>
-                <dd>{deployment.status.availableReplicas === deployment.status.updatedReplicas && deployment.spec.replicas === deployment.status.availableReplicas ? <Status status="Up to date" /> : <Status status="Updating" />}</dd>
+                <dd>
+                  <Status status={deploymentStatusReducer(deployment)} />
+                </dd>
               </ResourceSummary>
             </div>
             <div className="col-sm-6">

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -78,7 +78,9 @@ export const DeploymentDetailsList: React.FC<DeploymentDetailsListProps> = ({ de
 DeploymentDetailsList.displayName = 'DeploymentDetailsList';
 
 const getDeploymentStatus = (deployment: any): string => {
-  if (!deployment.status) return NO_STATUS;
+  if (!deployment.status) {
+    return NO_STATUS;
+  }
   return deployment.status.availableReplicas === deployment.status.updatedReplicas && deployment.spec.replicas === deployment.status.availableReplicas ? 'Up to date' : 'Updating';
 };
 

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -77,7 +77,7 @@ export const DeploymentDetailsList: React.FC<DeploymentDetailsListProps> = ({ de
 };
 DeploymentDetailsList.displayName = 'DeploymentDetailsList';
 
-const deploymentStatusReducer = (deployment: any): string => {
+const getDeploymentStatus = (deployment: any): string => {
   if (!deployment.status) return NO_STATUS;
   return deployment.status.availableReplicas === deployment.status.updatedReplicas && deployment.spec.replicas === deployment.status.availableReplicas ? 'Up to date' : 'Updating';
 };
@@ -102,7 +102,7 @@ const DeploymentDetails: React.FC<DeploymentDetailsProps> = ({ obj: deployment }
               <ResourceSummary resource={deployment} showPodSelector showNodeSelector showTolerations>
                 <dt>{t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_13')}</dt>
                 <dd>
-                  <Status status={deploymentStatusReducer(deployment)} />
+                  <Status status={getDeploymentStatus(deployment)} />
                 </dd>
               </ResourceSummary>
             </div>

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -18,7 +18,7 @@ import {
 
 import { alertingRuleIsActive, alertDescription, alertState, silenceState } from '../../reducers/monitoring';
 import { pipelineRunFilterReducer } from '@console/dev-console/src/utils/pipeline-filter-reducer';
-import { ServiceBrokerStatusReducer, ClusterServiceBrokerReducer, ServiceInstanceStatusReducer, TemplateInstanceStatusReducer } from '@console/dev-console/src/utils/hc-status-reducers';
+import * as reducers from '@console/dev-console/src/utils/hc-status-reducers';
 
 export const fuzzyCaseInsensitive = (a: string, b: string): boolean => fuzzy(_.toLower(a), _.toLower(b));
 
@@ -30,10 +30,15 @@ const pipelineApprovalStatusReducer = (pipelineApproval: any): string => {
   return pipelineApproval.status.result;
 };
 
-export const awxStatusReducer = (awx: any): string => {
-  const conditions = _.get(awx, ['status', 'conditions'], []);
-  if (conditions.length === 0) return '-';
-  return conditions[0].reason === 'Successful' ? 'Succeeded' : conditions[0].reason === 'Running' ? 'Deploying' : conditions[0].reason;
+const withTableFilter = reducer => {
+  const tableFilter = (results, obj) => {
+    if (!results || !results.selected || !results.selected.size) {
+      return true;
+    }
+    const result = reducer(obj);
+    return results.selected.has(result) || !_.includes(results.all, result);
+  };
+  return tableFilter;
 };
 
 // TODO: Table filters are undocumented, stringly-typed, and non-obvious. We can change that.
@@ -44,13 +49,8 @@ export const tableFilters: TableFilterMap = {
 
   'catalog-source-name': (filter, obj) => fuzzyCaseInsensitive(filter, obj.name),
 
-  'namespace-claim-status': (results, nameSpaceClaim) => {
-    if (!results || !results.selected || !results.selected.size) {
-      return true;
-    }
-    const result = nameSpaceClaim?.status?.status;
-    return results.selected.has(result) || !_.includes(results.all, result);
-  },
+  'namespace-claim-status': withTableFilter(reducers.baseStatusReducer('status', 'status')),
+
   'resource-quota-claim-status': (results, resourceQuotaClaim) => {
     if (!results || !results.selected || !results.selected.size) {
       return true;
@@ -181,14 +181,7 @@ export const tableFilters: TableFilterMap = {
     return phases.selected.has(phase) || !_.includes(phases.all, phase);
   },
 
-  'pod-status': (phases, pod) => {
-    if (!phases || !phases.selected || !phases.selected.size) {
-      return true;
-    }
-
-    const phase = podPhaseFilterReducer(pod);
-    return phases.selected.has(phase) || !_.includes(phases.all, phase);
-  },
+  'pod-status': withTableFilter(podPhaseFilterReducer),
 
   'registry-status': (phases, registry) => {
     if (!phases || !phases.selected || !phases.selected.size) {
@@ -204,7 +197,7 @@ export const tableFilters: TableFilterMap = {
       return true;
     }
 
-    const phase = ServiceBrokerStatusReducer(serviceBroker);
+    const phase = reducers.ServiceBrokerStatusReducer(serviceBroker);
     return phases.selected.has(phase) || !_.includes(phases.all, phase);
   },
 
@@ -213,7 +206,7 @@ export const tableFilters: TableFilterMap = {
       return true;
     }
 
-    const phase = ServiceInstanceStatusReducer(serviceInstance);
+    const phase = reducers.ServiceInstanceStatusReducer(serviceInstance);
     return phases.selected.has(phase) || !_.includes(phases.all, phase);
   },
   'cluster-service-broker-status': (phases, clusterServiceBroker) => {
@@ -221,7 +214,7 @@ export const tableFilters: TableFilterMap = {
       return true;
     }
 
-    const phase = ClusterServiceBrokerReducer(clusterServiceBroker);
+    const phase = reducers.ClusterServiceBrokerReducer(clusterServiceBroker);
     return phases.selected.has(phase) || !_.includes(phases.all, phase);
   },
 
@@ -343,19 +336,12 @@ export const tableFilters: TableFilterMap = {
       return true;
     }
 
-    const status = TemplateInstanceStatusReducer(instance);
+    const status = reducers.TemplateInstanceStatusReducer(instance);
 
     return statuses.selected.has(status) || !_.includes(statuses.all, status);
   },
 
-  'awx-status': (statuses, awx) => {
-    if (!statuses || !statuses.selected || !statuses.selected.size) {
-      return true;
-    }
-
-    const status = awxStatusReducer(awx);
-    return statuses.selected.has(status) || !_.includes(statuses.all, status);
-  },
+  'awx-status': withTableFilter(reducers.awxStatusReducer),
 
   machine: (str: string, machine: MachineKind): boolean => {
     const node: string = _.get(machine, 'status.nodeRef.name');

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -183,67 +183,19 @@ export const tableFilters: TableFilterMap = {
 
   'pod-status': withTableFilter(podPhaseFilterReducer),
 
-  'registry-status': (phases, registry) => {
-    if (!phases || !phases.selected || !phases.selected.size) {
-      return true;
-    }
+  'registry-status': withTableFilter(registryStatusReducer),
 
-    const phase = registryStatusReducer(registry);
-    return phases.selected.has(phase) || !_.includes(phases.all, phase);
-  },
+  'service-broker-status': withTableFilter(reducers.ServiceBrokerStatusReducer),
 
-  'service-broker-status': (phases, serviceBroker) => {
-    if (!phases || !phases.selected || !phases.selected.size) {
-      return true;
-    }
+  'service-instance-status': withTableFilter(reducers.ServiceInstanceStatusReducer),
 
-    const phase = reducers.ServiceBrokerStatusReducer(serviceBroker);
-    return phases.selected.has(phase) || !_.includes(phases.all, phase);
-  },
+  'cluster-service-broker-status': withTableFilter(reducers.ClusterServiceBrokerReducer),
 
-  'service-instance-status': (phases, serviceInstance) => {
-    if (!phases || !phases.selected || !phases.selected.size) {
-      return true;
-    }
+  'pipeline-run-status': withTableFilter(pipelineRunFilterReducer),
 
-    const phase = reducers.ServiceInstanceStatusReducer(serviceInstance);
-    return phases.selected.has(phase) || !_.includes(phases.all, phase);
-  },
-  'cluster-service-broker-status': (phases, clusterServiceBroker) => {
-    if (!phases || !phases.selected || !phases.selected.size) {
-      return true;
-    }
+  'pipeline-approval-status': withTableFilter(pipelineApprovalStatusReducer),
 
-    const phase = reducers.ClusterServiceBrokerReducer(clusterServiceBroker);
-    return phases.selected.has(phase) || !_.includes(phases.all, phase);
-  },
-
-  'pipeline-run-status': (results, pipelineRun) => {
-    if (!results || !results.selected || !results.selected.size) {
-      return true;
-    }
-
-    const result = pipelineRunFilterReducer(pipelineRun);
-    return results.selected.has(result) || !_.includes(results.all, result);
-  },
-
-  'pipeline-approval-status': (results, pipelineApproval) => {
-    if (!results || !results.selected || !results.selected.size) {
-      return true;
-    }
-
-    const result = pipelineApprovalStatusReducer(pipelineApproval);
-    return results.selected.has(result) || !_.includes(results.all, result);
-  },
-
-  'node-status': (statuses, node) => {
-    if (!statuses || !statuses.selected || !statuses.selected.size) {
-      return true;
-    }
-
-    const status = nodeStatus(node);
-    return statuses.selected.has(status) || !_.includes(statuses.all, status);
-  },
+  'node-status': withTableFilter(nodeStatus),
 
   'node-role': (roles, node) => {
     if (!roles || !roles.selected || !roles.selected.size) {
@@ -280,31 +232,11 @@ export const tableFilters: TableFilterMap = {
     return strategies.selected.has(strategy) || !_.includes(strategies.all, strategy);
   },
 
-  'route-status': (statuses, route) => {
-    if (!statuses || !statuses.selected || !statuses.selected.size) {
-      return true;
-    }
+  'route-status': withTableFilter(routeStatus),
 
-    const status = routeStatus(route);
-    return statuses.selected.has(status) || !_.includes(statuses.all, status);
-  },
+  'catalog-status': withTableFilter(serviceCatalogStatus),
 
-  'catalog-status': (statuses, catalog) => {
-    if (!statuses || !statuses.selected || !statuses.selected.size) {
-      return true;
-    }
-
-    const status = serviceCatalogStatus(catalog);
-    return statuses.selected.has(status) || !_.includes(statuses.all, status);
-  },
-
-  'secret-type': (types, secret) => {
-    if (!types || !types.selected || !types.selected.size) {
-      return true;
-    }
-    const type = secretTypeFilterReducer(secret);
-    return types.selected.has(type) || !_.includes(types.all, type);
-  },
+  'secret-type': withTableFilter(secretTypeFilterReducer),
 
   'project-name': (str: string, project: K8sResourceKind) => {
     const displayName = _.get(project, ['metadata', 'annotations', 'openshift.io/display-name']);
@@ -322,24 +254,9 @@ export const tableFilters: TableFilterMap = {
     return fuzzyCaseInsensitive(str, displayName);
   },
 
-  'cluster-operator-status': (statuses, operator) => {
-    if (!statuses || !statuses.selected || !statuses.selected.size) {
-      return true;
-    }
+  'cluster-operator-status': withTableFilter(getClusterOperatorStatus),
 
-    const status = getClusterOperatorStatus(operator);
-    return statuses.selected.has(status) || !_.includes(statuses.all, status);
-  },
-
-  'template-instance-status': (statuses, instance) => {
-    if (!statuses || !statuses.selected || !statuses.selected.size) {
-      return true;
-    }
-
-    const status = reducers.TemplateInstanceStatusReducer(instance);
-
-    return statuses.selected.has(status) || !_.includes(statuses.all, status);
-  },
+  'template-instance-status': withTableFilter(reducers.TemplateInstanceStatusReducer),
 
   'awx-status': withTableFilter(reducers.awxStatusReducer),
 

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -49,7 +49,7 @@ export const tableFilters: TableFilterMap = {
 
   'catalog-source-name': (filter, obj) => fuzzyCaseInsensitive(filter, obj.name),
 
-  'namespace-claim-status': withTableFilter(reducers.baseStatusReducer('status', 'status')),
+  'namespace-claim-status': withTableFilter(reducers.NamespaceClaimReducer),
 
   'resource-quota-claim-status': (results, resourceQuotaClaim) => {
     if (!results || !results.selected || !results.selected.size) {
@@ -258,7 +258,7 @@ export const tableFilters: TableFilterMap = {
 
   'template-instance-status': withTableFilter(reducers.TemplateInstanceStatusReducer),
 
-  'awx-status': withTableFilter(reducers.awxStatusReducer),
+  'awx-status': withTableFilter(reducers.AwxStatusReducer),
 
   machine: (str: string, machine: MachineKind): boolean => {
     const node: string = _.get(machine, 'status.nodeRef.name');

--- a/frontend/public/components/hypercloud/awx.tsx
+++ b/frontend/public/components/hypercloud/awx.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { K8sResourceKind } from '../../module/k8s';
 import { DetailsPage, ListPage, DetailsPageProps } from '../factory';
-import { awxStatusReducer } from '@console/dev-console/src/utils/hc-status-reducers';
+import { AwxStatusReducer } from '@console/dev-console/src/utils/hc-status-reducers';
 import { DetailsItem, Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
 import { Status } from '@console/shared';
 import { AWXModel } from '../../models';
@@ -27,7 +27,7 @@ const tableProps: TableProps = {
     },
     {
       title: 'COMMON:MSG_MAIN_TABLEHEADER_3',
-      sortFunc: 'awxStatusReducer',
+      sortFunc: 'AwxStatusReducer',
     },
     {
       title: 'COMMON:MSG_MAIN_TABLEHEADER_12',
@@ -49,7 +49,7 @@ const tableProps: TableProps = {
     },
     {
       className: classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'co-break-word'),
-      children: <Status status={awxStatusReducer(obj)} />,
+      children: <Status status={AwxStatusReducer(obj)} />,
     },
     {
       children: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
@@ -65,7 +65,7 @@ const filters = (t: TFunction) => [
   {
     filterGroupName: t('COMMON:MSG_COMMON_FILTER_10'),
     type: 'awx-status',
-    reducer: awxStatusReducer,
+    reducer: AwxStatusReducer,
     items: [
       { id: 'Succeeded', title: 'Succeeded' },
       { id: 'Deploying', title: 'Deploying' },
@@ -95,7 +95,7 @@ export const AWXDetailsList: React.FC<AWXDetailsListProps> = ({ obj: awx }) => {
   return (
     <dl className="co-m-pane__details">
       <DetailsItem label={t('MULTI:MSG_MULTI_AWXINSTANCES_AWXINSTANCEDETAILS_1')} obj={awx}>
-        <Status status={awxStatusReducer(awx)} />
+        <Status status={AwxStatusReducer(awx)} />
       </DetailsItem>
       <DetailsItem label={t('MULTI:MSG_MULTI_AWXINSTANCES_AWXINSTANCEDETAILS_2')} obj={awx} path="spec.tower_hostname">
         {awx.spec?.tower_hostname ? (
@@ -141,7 +141,7 @@ export const AWXsPage: React.FC = props => {
 
 export const AWXsDetailsPage: React.FC<DetailsPageProps> = props => {
   const [url, setUrl] = React.useState(null);
-  return <DetailsPage {...props} kind={kind} menuActions={menuActions} customData={{ label: 'URL', url: url ? `https://${url}` : null }} customStatePath="spec.tower_hostname" setCustomState={setUrl} getResourceStatus={awxStatusReducer} pages={[details(detailsPage(AWXDetails)), editResource()]} />;
+  return <DetailsPage {...props} kind={kind} menuActions={menuActions} customData={{ label: 'URL', url: url ? `https://${url}` : null }} customStatePath="spec.tower_hostname" setCustomState={setUrl} getResourceStatus={AwxStatusReducer} pages={[details(detailsPage(AWXDetails)), editResource()]} />;
 };
 
 type ImageSummaryProps = {

--- a/frontend/public/components/hypercloud/awx.tsx
+++ b/frontend/public/components/hypercloud/awx.tsx
@@ -1,9 +1,8 @@
-import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { K8sResourceKind } from '../../module/k8s';
 import { DetailsPage, ListPage, DetailsPageProps } from '../factory';
-import { awxStatusReducer } from '../factory/table-filters';
+import { awxStatusReducer } from '@console/dev-console/src/utils/hc-status-reducers';
 import { DetailsItem, Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
 import { Status } from '@console/shared';
 import { AWXModel } from '../../models';

--- a/frontend/public/components/hypercloud/namespace-claim.tsx
+++ b/frontend/public/components/hypercloud/namespace-claim.tsx
@@ -9,7 +9,7 @@ import { Kebab, navFactory, ResourceSummary, SectionHeading, ResourceLink, Resou
 import { useTranslation } from 'react-i18next';
 import { NamespaceClaimModel } from '../../models';
 import { TableProps } from './utils/default-list-component';
-import { baseStatusReducer } from '@console/dev-console/src/utils/hc-status-reducers';
+import { NamespaceClaimReducer } from '@console/dev-console/src/utils/hc-status-reducers';
 
 const { common } = Kebab.factory;
 
@@ -68,11 +68,11 @@ const tableProps: TableProps = {
           obj?.status?.status === 'Error' ? (
             <Popover headerContent={<div>에러 상세</div>} bodyContent={<div>{obj.status?.reason}</div>} maxWidth="30rem" position="right">
               <div style={{ width: 'fit-content', cursor: 'pointer', color: '#0066CC' }}>
-                <Status status={baseStatusReducer('status', 'status')(obj)} />
+                <Status status={NamespaceClaimReducer(obj)} />
               </div>
             </Popover>
           ) : (
-            <Status status={baseStatusReducer('status', 'status')(obj)} />
+            <Status status={NamespaceClaimReducer(obj)} />
           ),
       },
       {
@@ -93,7 +93,7 @@ const filters = t => [
   {
     filterGroupName: t('COMMON:MSG_COMMON_FILTER_10'),
     type: 'namespace-claim-status',
-    reducer: baseStatusReducer('status', 'status'),
+    reducer: NamespaceClaimReducer,
     items: [
       { id: 'Awaiting', title: 'Awaiting' },
       { id: 'Approved', title: 'Approved' },
@@ -137,7 +137,7 @@ const NamespaceClaimsDetails: React.FC<NamespaceClaimDetailsProps> = ({ obj: nam
                 <dd>{namespaceclaims.resourceName}</dd>
                 <dt>{t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_45')}</dt>
                 <dd>
-                  <Status status={baseStatusReducer('status', 'status')(namespaceclaims)} />
+                  <Status status={NamespaceClaimReducer(namespaceclaims)} />
                 </dd>
                 {namespaceclaims.status?.status === 'Rejected' && (
                   <>

--- a/frontend/public/components/hypercloud/namespace-claim.tsx
+++ b/frontend/public/components/hypercloud/namespace-claim.tsx
@@ -9,6 +9,7 @@ import { Kebab, navFactory, ResourceSummary, SectionHeading, ResourceLink, Resou
 import { useTranslation } from 'react-i18next';
 import { NamespaceClaimModel } from '../../models';
 import { TableProps } from './utils/default-list-component';
+import { baseStatusReducer } from '@console/dev-console/src/utils/hc-status-reducers';
 
 const { common } = Kebab.factory;
 
@@ -67,11 +68,11 @@ const tableProps: TableProps = {
           obj?.status?.status === 'Error' ? (
             <Popover headerContent={<div>에러 상세</div>} bodyContent={<div>{obj.status?.reason}</div>} maxWidth="30rem" position="right">
               <div style={{ width: 'fit-content', cursor: 'pointer', color: '#0066CC' }}>
-                <Status status={obj?.status?.status} />
+                <Status status={baseStatusReducer('status', 'status')(obj)} />
               </div>
             </Popover>
           ) : (
-            <Status status={obj?.status?.status} />
+            <Status status={baseStatusReducer('status', 'status')(obj)} />
           ),
       },
       {
@@ -88,15 +89,11 @@ const tableProps: TableProps = {
   },
 };
 
-const namespaceClaimStatusReducer = (nsc: any): string => {
-  return nsc?.status?.status;
-};
-
 const filters = t => [
   {
     filterGroupName: t('COMMON:MSG_COMMON_FILTER_10'),
     type: 'namespace-claim-status',
-    reducer: namespaceClaimStatusReducer,
+    reducer: baseStatusReducer('status', 'status'),
     items: [
       { id: 'Awaiting', title: 'Awaiting' },
       { id: 'Approved', title: 'Approved' },
@@ -139,9 +136,8 @@ const NamespaceClaimsDetails: React.FC<NamespaceClaimDetailsProps> = ({ obj: nam
                 <dt>{t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_118')}</dt>
                 <dd>{namespaceclaims.resourceName}</dd>
                 <dt>{t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_45')}</dt>
-                {/* <dd>{namespaceclaims.status?.status}</dd> */}
                 <dd>
-                  <Status status={namespaceclaims.status?.status} />
+                  <Status status={baseStatusReducer('status', 'status')(namespaceclaims)} />
                 </dd>
                 {namespaceclaims.status?.status === 'Rejected' && (
                   <>

--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { Status } from '@console/shared';
+import { NO_STATUS, Status } from '@console/shared';
 import { getJobTypeAndCompletions, K8sKind, JobKind, K8sResourceKind } from '../module/k8s';
 import { Conditions } from './conditions';
 import { DetailsPage, ListPage } from './factory';
@@ -101,7 +101,7 @@ const tableProps: TableProps = {
 };
 
 const jobStatus = (job: JobKind): string => {
-  return job && job.status ? _.get(job, 'status.conditions[0].type', 'In Progress') : null;
+  return job && job.status ? _.get(job, 'status.conditions[0].type', 'In Progress') : NO_STATUS;
 };
 
 const JobDetails: React.FC<JobsDetailsProps> = ({ obj: job }) => {

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -28,7 +28,7 @@ import { Overview } from './overview';
 import { getNamespaceDashboardConsoleLinks, ProjectDashboard } from './dashboard/project-dashboard/project-dashboard';
 import { removeQueryArgument } from './utils/router';
 import { useTranslation, withTranslation } from 'react-i18next';
-
+import { baseStatusReducer } from '@console/dev-console/src/utils/hc-status-reducers';
 import NamespaceOverview from './namespace-overview';
 import { RoleBindingClaimsPage } from './hypercloud/role-binding-claim';
 
@@ -120,7 +120,7 @@ const namespacesTableProps = {
       },
       {
         classNames: 'co-break-word',
-        children: <Status status={obj.status.phase} />,
+        children: <Status status={baseStatusReducer('status', 'phase')(obj)} />,
       },
       {
         children: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
@@ -478,7 +478,7 @@ export const NamespaceSummary = ({ ns }) => {
       <div className="col-sm-6 col-xs-12">
         <dl className="co-m-pane__details">
           <DetailsItem label={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_13')} obj={ns} path="status.phase">
-            <Status status={ns.status.phase} />
+            <Status status={baseStatusReducer('status', 'phase')(ns)} />
           </DetailsItem>
           {canListSecrets && (
             <>

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -28,7 +28,6 @@ import { Overview } from './overview';
 import { getNamespaceDashboardConsoleLinks, ProjectDashboard } from './dashboard/project-dashboard/project-dashboard';
 import { removeQueryArgument } from './utils/router';
 import { useTranslation, withTranslation } from 'react-i18next';
-import { baseStatusReducer } from '@console/dev-console/src/utils/hc-status-reducers';
 import NamespaceOverview from './namespace-overview';
 import { RoleBindingClaimsPage } from './hypercloud/role-binding-claim';
 
@@ -88,6 +87,10 @@ const fetchNamespaceMetrics = () => {
   return Promise.all(promises).then(data => _.assign({}, ...data));
 };
 
+const getNamespaceStatus = namespace => {
+  return !!namespace.status ? namespace.status.phase : NO_STATUS;
+};
+
 const namespacesTableProps = {
   header: [
     {
@@ -120,7 +123,7 @@ const namespacesTableProps = {
       },
       {
         classNames: 'co-break-word',
-        children: <Status status={baseStatusReducer('status', 'phase')(obj)} />,
+        children: <Status status={getNamespaceStatus(obj)} />,
       },
       {
         children: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
@@ -478,7 +481,7 @@ export const NamespaceSummary = ({ ns }) => {
       <div className="col-sm-6 col-xs-12">
         <dl className="co-m-pane__details">
           <DetailsItem label={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_13')} obj={ns} path="status.phase">
-            <Status status={baseStatusReducer('status', 'phase')(ns)} />
+            <Status status={getNamespaceStatus(ns)} />
           </DetailsItem>
           {canListSecrets && (
             <>

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -153,7 +153,7 @@ export const ReplicationControllerModel: K8sKind = {
 export const HorizontalPodAutoscalerModel: K8sKind = {
   label: 'Horizontal Pod Autoscaler',
   plural: 'horizontalpodautoscalers',
-  apiVersion: 'v2beta1',
+  apiVersion: 'v2beta2',
   apiGroup: 'autoscaling',
   abbr: 'HPA',
   namespaced: true,

--- a/frontend/public/module/k8s/pods.ts
+++ b/frontend/public/module/k8s/pods.ts
@@ -210,7 +210,7 @@ export const podReadiness = (pod: PodKind): { readyCount: number; totalContainer
 // (See https://github.com/kubernetes/kubernetes/blob/release-1.17/pkg/printers/internalversion/printers.go)
 export const podPhase = (pod: PodKind): PodPhase => {
   if (!pod || !pod.status) {
-    return '';
+    return 'No Status';
   }
 
   if (pod.metadata.deletionTimestamp) {


### PR DESCRIPTION
- 홈(네임스페이스, 네임스페이스 클레임), 워크로드(파드, 디플로이먼트, 잡), 앤서블 메뉴에 대해 no status 처리   
- table-filter.ts에 withTableFilter 함수를 생성해 기존에 중복해 작성하던 코드 제거   
- [bugfix][patch] IMS 269431 - HPA yaml view 예제 api 버전 수정