### PR TITLE
[bugfix][patch][IMS]268692 테스크 런과 파이프라인 생성시 task parameter 필수값이 다른 현상

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
@@ -307,21 +307,29 @@ const applyParamsUpdate = (
   params: UpdateTaskParamData,
 ): PipelineTask => {
   const { newValue, taskParamName } = params;
+  let newParams;
+  let exist = false;
+  
+  newParams = pipelineTask.params.map(
+    (param): PipelineTaskParam => {
+      if (param.name !== taskParamName) {
+        return param;
+      }
+      exist = true;
+
+      return {
+        ...param,
+        value: newValue,
+      };
+    },
+  )
+  if (!exist) {
+    newParams.push({name: taskParamName, value: newValue});
+  }
 
   return {
     ...pipelineTask,
-    params: pipelineTask.params.map(
-      (param): PipelineTaskParam => {
-        if (param.name !== taskParamName) {
-          return param;
-        }
-
-        return {
-          ...param,
-          value: newValue,
-        };
-      },
-    ),
+    params: newParams,
   };
 };
 


### PR DESCRIPTION
현상
파이프라인 사이드바에서 태스크 파라미터가 array에 default가 없는 경우 입력이 안되는 현상

원인
기존 파라미터 이름이 있을 때만 업데이트 되던 문제

해결
새로운 파라미터가 생겼으면 추가하도록 함