### PR TITLE
[bugfix][patch][IMS]270928 - cicd 메뉴 국문화 요청

### DIFF
--- a/frontend/public/module/k8s/k8s.ts
+++ b/frontend/public/module/k8s/k8s.ts
@@ -9,7 +9,7 @@ export const multiClusterBasePath = `${window.SERVER_FLAGS.basePath}api/multi-hy
 
 // TODO(alecmerdler): Replace all manual string building with this function
 export const referenceForGroupVersionKind = (group: string) => (version: string) => (kind: string) => {
-  if (kind === 'PipelineResource' || kind === 'ClusterTask' || kind === 'Task' || kind === 'ServiceClass' || kind === 'ClusterServiceClass') {
+  if (kind === 'Task' || kind === 'ClusterTask' || kind === 'TaskRun' || kind === 'Pipeline' || kind === 'PipelineRun' || kind === 'PipelineResource' || kind === 'ServiceClass' || kind === 'ClusterServiceClass') {
     return kind;
   }
   return [group, version, kind].join('~');


### PR DESCRIPTION
[문제]
CI/CD 에서 Task Run, Pipeline, Pipeline Run 영문으로 나옴
[원인]
public/modesls/hypercloud/intex.ts 에서 model을 찾는게 아니라 packages/dev-console/src/models/pipelines.ts 에서 찾음
getI18nInfo 에서 

public/models/hypercloud/resource-plural.ts 에서 kindObj - model 에서 ref - string 변환 후 다시 model 로 변환하는데 이 과정에서 ref 가 tekton.dev~v1beta1~Pipeline 형식으로 변환 되고 이걸 modelFor(ref)에서 pipelines.ts 참조하게됨
```
const getI18nInfo = (kindObj: any) => {

const ref = referenceForModel(kindObj); → ref 가 tekton.dev~v1beta1~Pipeline 형식으로 변환

const model = modelFor(ref); → pipeline.ts 에서 model 참조하게됨

return model?.i18nInfo || model;

};
```
[해결]
referenceForModel 에서 Task 등은 예외 처리를 이미 하고 있어서 여기에 추가함
getI18nInfo 구조 변경은 논의 후 진행해야 할듯 하여 우선 예외 추가 형식으로 수정

```
if (kind === 'PipelineResource' || kind === 'ClusterTask' || kind === 'Task' || kind === 'ServiceClass' || kind === 'ClusterServiceClass') {

return kind;

}
```