### PR TITLE
[bugfix][patch][IMS]268692 테스크 런과 파이프라인 생성시 task parameter 필수값이 다른 현상

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
@@ -58,9 +58,11 @@ const removeListRunAfters = (task: PipelineTask, listIds: string[]): PipelineTas
 const removeEmptyDefaultParams = (task: PipelineTask): PipelineTask => {
   if (task.params?.length > 0) {
     // Since we can submit, this param has a default; check for empty values and remove
+    // 20210929 Policy changed
+    task.params.forEach(param => {if(param.value === undefined) param.value = '' });
     return {
       ...task,
-      params: task.params.filter(param => !!param.value),
+      //params: task.params.filter(param => !!param.value),
     };
   }
 

--- a/frontend/public/components/hypercloud/form/taskruns/create-taskrun.tsx
+++ b/frontend/public/components/hypercloud/form/taskruns/create-taskrun.tsx
@@ -189,7 +189,7 @@ const CreateTaskRunComponent: React.FC<TaskRunFormProps> = props => {
             <Section label={item.name} id={`${selectedTask}_param_${index}`} key={`${selectedTask}_param_${index}`} description={item.description} isRequired={false}>
               <>
                 <input ref={methods.register} type="hidden" id={`params.${index}.name`} name={`params.${index}.name`} value={item.name} />
-                <ListView name={`params.${index}.value`} methods={methods} addButtonText="추가" headerFragment={<></>} itemRenderer={paramItemRenderer} defaultItem={{ value: '' }} defaultValues={lists.paramValueListData[index]?.value} />
+                <ListView name={`params.${index}.value`} methods={methods} addButtonText={t('COMMON:MSG_COMMON_BUTTON_COMMIT_8')} headerFragment={<></>} itemRenderer={paramItemRenderer} defaultItem={{ value: '' }} defaultValues={lists.paramValueListData[index]?.value} />
               </>
             </Section>
           );

--- a/frontend/public/components/hypercloud/form/utils/workspaces.tsx
+++ b/frontend/public/components/hypercloud/form/utils/workspaces.tsx
@@ -6,6 +6,7 @@ import { RadioGroup } from '../../utils/radio';
 import { Dropdown } from '../../utils/dropdown';
 import { TextInput } from '../../utils/text-input';
 import { ResourceDropdown } from '../../utils/resource-dropdown';
+import { useTranslation } from 'react-i18next';
 
 const workspaceType = {
   VolumeClaimTemplate: 'Volume Claim Template',
@@ -31,6 +32,7 @@ const accessItems = [
 ];
 
 export const Workspace = props => {
+  const { t } = useTranslation();
   const workspace = useWatch<string>({
     control: props.methods.control,
     name: `${props.id}.name.${props.name}`,
@@ -39,19 +41,19 @@ export const Workspace = props => {
   const workspaceDetail = {
     VolumeClaimTemplate: (
       <>
-        <Section label='접근 모드' id='accessMode'>
+        <Section label={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_14')} id='accessMode'>
           <RadioGroup name={`${props.id}.volumeClaimTemplate.spec.accessModes`} items={accessItems} methods={props.methods} />
         </Section>
-        <Section label='스토리지 크기' id='storage'>
+        <Section label={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_12')} id='storage'>
           <TextInput className='pf-c-form-control' id={`${props.id}.volumeClaimTemplate.spec.resources.requests.storage`} methods={props.methods} />
         </Section>
-        <Section label='스토리지 클래스 이름' id='storageClass'>
+        <Section label={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_13')} id='storageClass'>
           <TextInput className='pf-c-form-control' id={`${props.id}.volumeClaimTemplate.spec.storageClassName`} methods={props.methods} />
         </Section>
       </>),
     PVC: (
       <>
-        <Section label='영구 볼륨 클레임' id='pvc'>
+        <Section label={t('COMMON:MSG_LNB_MENU_141')} id='pvc'>
           <ResourceDropdown
             name={`${props.id}.persistentVolumeClaim.claimName`}
             resources={[
@@ -70,7 +72,7 @@ export const Workspace = props => {
     ),
     ConfigMap: (
       <>
-        <Section label='컨피그 맵' id='configmap'>
+        <Section label={t('COMMON:MSG_LNB_MENU_120')} id='configmap'>
           <ResourceDropdown
             name={`${props.id}.configmap.name`}
             resources={[
@@ -89,7 +91,7 @@ export const Workspace = props => {
     ),
     Secret: (
       <>
-        <Section label='시크릿' id='secret'>
+        <Section label={t('COMMON:MSG_LNB_MENU_119')} id='secret'>
           <ResourceDropdown
             name={`${props.id}.secret.secretName`}
             resources={[
@@ -113,7 +115,7 @@ export const Workspace = props => {
     <Section label={props.name} id={props.name}>
       <Dropdown
         name={`${props.id}.name.${props.name}`}
-        title='워크스페이스 타입 선택'
+        title={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_10')}
         items={workspaceType}
       />
     </Section>


### PR DESCRIPTION
pipeline 의 task 에서도 taskrun 같이 parameter 입력이 없으면 value를 '' 로 넣어주기로 함

pieline 생성 페이지의 task side bar에서 값이 없으면 '' 을 넣어 주고 있었지만,

submit 할때  parameter 의 값이 없으면(!!param.value) parameter 를 빼는 부분이 존재하여서 주석 처리

undefined 생성되는 경우가 있어서 이 경우 parameter의 value를 '' 로 넣어줌

task 의 parameter 가 기본값이 아예 없을 수가 있어서 undefined 값이 있으면 '' 로 변경 로직 필요
(hypercloud ui에서 create-task 했을때는 없도록 조치 했을것 같습니다만, 따로 생성하거나 기존 생성했던 task 등에서 기본값 없는 경우 등 대비 필요)
![image](https://user-images.githubusercontent.com/48277126/136167594-0a2c455d-4473-4cab-b5ff-ade1896bf8e7.png)

기타 i18n 수정