### PR TITLE
[bugfix][patch][IMS]268692 테스크 런과 파이프라인 생성시 task parameter 필수값이 다른 현상

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -57,6 +57,13 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = props => {
 
   const updateTasks = (changes: CleanupResults): void => {
     const { tasks, listTasks, errors: taskErrors } = changes;
+    tasks.forEach(task => {
+      task?.params?.forEach(param => {
+        if ( param.value === undefined) {
+          param.value = (param.type &&  param.type === 'array')  ? [''] : '';
+        }
+      });
+    });
 
     setFieldValue('tasks', tasks);
     setFieldValue('listTasks', listTasks);

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
@@ -33,6 +33,7 @@ export const convertResourceToTask = (resource: PipelineResourceTask, runAfter?:
     params: getTaskParameters(resource).map(param => ({
       name: param.name,
       value: param.default,
+      type: param.type
     })),
   };
 };
@@ -59,7 +60,7 @@ const removeEmptyDefaultParams = (task: PipelineTask): PipelineTask => {
   if (task.params?.length > 0) {
     // Since we can submit, this param has a default; check for empty values and remove
     // 20210929 Policy changed
-    task.params.forEach(param => {if(param.value === undefined) param.value = '' });
+    task.params.forEach(param => { if (param.value === undefined) { param.value = (param.type && param.type === 'array') ?  [''] : ''; }; delete param.type; });
     return {
       ...task,
       //params: task.params.filter(param => !!param.value),

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -48,6 +48,7 @@ export interface PipelineTaskRef {
 export interface PipelineTaskParam {
   name: string;
   value: any;
+  type?: string;
 }
 export interface PipelineTaskResources {
   inputs?: PipelineTaskResource[];

--- a/frontend/public/components/hypercloud/form/taskruns/create-taskrun.tsx
+++ b/frontend/public/components/hypercloud/form/taskruns/create-taskrun.tsx
@@ -189,7 +189,7 @@ const CreateTaskRunComponent: React.FC<TaskRunFormProps> = props => {
             <Section label={item.name} id={`${selectedTask}_param_${index}`} key={`${selectedTask}_param_${index}`} description={item.description} isRequired={false}>
               <>
                 <input ref={methods.register} type="hidden" id={`params.${index}.name`} name={`params.${index}.name`} value={item.name} />
-                <ListView name={`params.${index}.value`} methods={methods} addButtonText={t('COMMON:MSG_COMMON_BUTTON_COMMIT_8')} headerFragment={<></>} itemRenderer={paramItemRenderer} defaultItem={{ value: '' }} defaultValues={lists.paramValueListData[index]?.value} />
+                <ListView name={`params.${index}.value`} methods={methods} addButtonText={t('COMMON:MSG_COMMON_BUTTON_COMMIT_8')} headerFragment={<></>} itemRenderer={paramItemRenderer} defaultItem={{ value: '' }} defaultValues={lists.paramValueListData[index]?.value || [{value: ''}]} />
               </>
             </Section>
           );


### PR DESCRIPTION
pipeline 생성시 task의 parameter가 array type 이고 빈 값이면 string type '' 값으로 submit 되는 현상이 있었음

task update 할때 parameter의 type 같이 보내게 하고 type 확인하여 초기값 설정을 해줌

submit 할때는 다시 type 제거