### PR TITLE
ClusteMenuPolicy 리스트, 디테일페이지 추가 구현, 싱글클러스터 탭에서 불리는 콜들 ingress주소조회 후 설정되도록 수정

### DIFF
--- a/frontend/packages/dev-console/src/utils/hc-status-reducers.ts
+++ b/frontend/packages/dev-console/src/utils/hc-status-reducers.ts
@@ -1,5 +1,6 @@
 import * as _ from 'lodash-es';
 import { NodeCondition } from '@console/shared/src/types';
+import { CMP_PRIMARY_KEY } from '@console/internal/hypercloud/menu/menu-types';
 export const NO_STATUS = 'No Status';
 
 export const ServiceBrokerStatusReducer = instance => {
@@ -212,5 +213,15 @@ export const ClusterRegistrationStatusReducer = (cr: any): string => {
     }
   } else {
     return NO_STATUS;
+  }
+};
+
+export const ClusterMenuPolicyStatusReducer = (cmp: any): string => {
+  const labels = cmp?.metadata?.labels;
+  const primaryValue = _.get(labels, CMP_PRIMARY_KEY);
+  if (primaryValue === 'true') {
+    return '활성화 됨';
+  } else {
+    return '활성화되지 않음';
   }
 };

--- a/frontend/public/co-fetch.js
+++ b/frontend/public/co-fetch.js
@@ -4,6 +4,7 @@ import { getIdToken } from './hypercloud/auth';
 import { authSvc } from './module/auth';
 import store from './redux';
 import keycloak from './hypercloud/keycloak';
+import { isSingleClusterPerspective, getSingleClusterFullBasePath } from './hypercloud/perspectives';
 
 const initDefaults = {
   headers: {},
@@ -156,6 +157,11 @@ export const coFetchCommon = (url, method = 'GET', options = {}, timeout) => {
     if (kind === 'Group') {
       headers['Impersonate-Group'] = name;
     }
+  }
+
+  if (url.indexOf('https://') < 0 && url.indexOf('http://') < 0 && isSingleClusterPerspective()) {
+    // MEMO : 도메인 뒷부분만 url로 들어오는 경우, singlecluster perspective면 ingress 도메인 주소로 설정해줘야함.
+    url = `${getSingleClusterFullBasePath()}${url}`;
   }
   // Pass headers last to let callers to override Accept.
   const allOptions = _.defaultsDeep({ method }, options, { headers });

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -30,6 +30,7 @@ import { Page } from '@patternfly/react-core';
 import keycloak from '../hypercloud/keycloak';
 import { setAccessToken, setIdToken, setId, resetLoginState } from '../hypercloud/auth';
 import { initializationForMenu } from '@console/internal/components/hypercloud/utils/menu-utils';
+import { isSingleClusterPerspective } from '@console/internal/hypercloud/perspectives';
 
 const breakpointMD = 768;
 const NOTIFICATION_DRAWER_BREAKPOINT = 1800;
@@ -134,7 +135,7 @@ class App extends React.PureComponent {
       <>
         <Helmet titleTemplate={`%s · ${productName}`} defaultTitle={productName} />
         <ConsoleNotifier location="BannerTop" />
-        <Page header={<Masthead keycloak={keycloak} onNavToggle={this._onNavToggle} />} sidebar={<Navigation isNavOpen={isNavOpen} onNavSelect={this._onNavSelect} onPerspectiveSelected={this._onNavSelect} onClusterSelected={this._onNavSelect} />}>
+        <Page header={<Masthead keycloak={keycloak} onNavToggle={this._onNavToggle} />} sidebar={<Navigation isNavOpen={isNavOpen} onNavSelect={this._onNavSelect} onPerspectiveSelected={this._onNavSelect} onClusterSelected={this._onNavSelect} isSingleClusterPerspective={isSingleClusterPerspective()} />}>
           <ConnectedNotificationDrawer isDesktop={isDrawerInline} onDrawerChange={this._onNotificationDrawerToggle}>
             <AppContents />
           </ConnectedNotificationDrawer>

--- a/frontend/public/components/hypercloud/cluster-menu-policy.tsx
+++ b/frontend/public/components/hypercloud/cluster-menu-policy.tsx
@@ -1,0 +1,236 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Accordion, AccordionContent, AccordionItem, AccordionToggle } from '@patternfly/react-core';
+import { K8sResourceKind, K8sKind, k8sPatch, k8sList } from '@console/internal/module/k8s';
+import { DetailsPage, ListPage } from '../factory';
+import { Kebab, KebabAction, detailsPage, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading, Timestamp } from '../utils';
+import { ClusterMenuPolicyModel } from '../../models';
+import { TableProps } from './utils/default-list-component';
+import { ClusterMenuPolicyStatusReducer } from '@console/dev-console/src/utils/hc-status-reducers';
+import { SelectorInput } from '@console/internal/components/utils';
+import { MenuType } from '@console/internal/hypercloud/menu/menu-types';
+import { errorModal } from '../modals/error-modal';
+import { ResourceLabel } from '@console/internal/models/hypercloud/resource-plural';
+import { getMenuTitle, getContainerLabel } from '@console/internal/components/hypercloud/utils/menu-utils';
+
+const kind = ClusterMenuPolicyModel.kind;
+
+const toggleActivated = (model: K8sKind, obj: K8sResourceKind) => {
+  const truePatch = [
+    {
+      path: '/metadata/labels',
+      op: 'replace',
+      value: SelectorInput.objectify(['primary=true']),
+    },
+  ];
+
+  const falsePatch = [
+    {
+      path: '/metadata/labels',
+      op: 'replace',
+      value: SelectorInput.objectify(['primary=false']),
+    },
+  ];
+
+  k8sList(ClusterMenuPolicyModel).then(cmpList => {
+    cmpList?.forEach(cmp => {
+      if (obj.metadata?.name !== cmp.metadata?.name) {
+        k8sPatch(model, cmp, falsePatch);
+      }
+    });
+  });
+
+  return k8sPatch(model, obj, truePatch);
+};
+
+const deactivateCmp = (model: K8sKind, obj: K8sResourceKind) => {
+  const falsePatch = [
+    {
+      path: '/metadata/labels',
+      op: 'replace',
+      value: SelectorInput.objectify(['primary=false']),
+    },
+  ];
+
+  return k8sPatch(model, obj, falsePatch);
+};
+
+const ActivateAction: KebabAction = (kind: K8sKind, obj: any) => {
+  const primaryValue = obj?.metadata?.labels?.primary;
+  return {
+    label: primaryValue === 'true' ? '비활성화' : '활성화',
+    callback: () => (primaryValue === 'true' ? deactivateCmp(kind, obj).catch(err => errorModal({ error: err.message })) : toggleActivated(kind, obj).catch(err => errorModal({ error: err.message }))),
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.plural,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'patch',
+    },
+  };
+};
+
+const menuActions: KebabAction[] = [ActivateAction, ...Kebab.factory.common];
+
+const tableProps: TableProps = {
+  header: [
+    {
+      title: 'COMMON:MSG_MAIN_TABLEHEADER_1',
+      sortField: 'metadata.name',
+    },
+    {
+      title: '활성화 여부',
+      sortFunc: 'ClusterMenuPolicyStatusReducer',
+    },
+    {
+      title: 'COMMON:MSG_MAIN_TABLEHEADER_12',
+      sortField: 'metadata.creationTimestamp',
+    },
+    {
+      title: '',
+      transforms: null,
+      props: { className: Kebab.columnClass },
+    },
+  ],
+  row: (obj: K8sResourceKind) => [
+    {
+      children: <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.uid} />,
+    },
+    {
+      children: <>{ClusterMenuPolicyStatusReducer(obj)}</>,
+    },
+    {
+      children: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
+    },
+    {
+      className: Kebab.columnClass,
+      children: <ResourceKebab actions={menuActions} kind={kind} resource={obj} />,
+    },
+  ],
+  customSorts: {
+    ClusterMenuPolicyStatusReducer,
+  },
+};
+
+type MenuContentItem = {
+  title: string;
+  childrenMenus: string[];
+};
+
+type AccordionBlockProps = {
+  title: string;
+  contentData: MenuContentItem[];
+  onToggle: any;
+  expanded: string[];
+  index: number;
+};
+
+const AccordionBlock = (props: AccordionBlockProps) => {
+  const { title, contentData, onToggle, expanded, index } = props;
+  const toggleId = `${title}-toggle${index}`;
+  const contentId = `${title}-content${index}`;
+
+  const menuDetails = contentData?.map(data => {
+    return (
+      <>
+        <div style={{ fontSize: 15, borderBottom: '1px solid' }}>{data.title}</div>
+        {data.childrenMenus?.map(menuString => (
+          <span style={{ marginLeft: 20 }}>{menuString}</span>
+        ))}
+      </>
+    );
+  });
+  return (
+    <AccordionItem>
+      <AccordionToggle
+        id={toggleId}
+        onClick={() => {
+          onToggle(toggleId);
+        }}
+        isExpanded={expanded.includes(toggleId)}
+      >
+        {title}
+      </AccordionToggle>
+      <AccordionContent id={contentId} isHidden={!expanded.includes(toggleId)}>
+        {menuDetails}
+      </AccordionContent>
+    </AccordionItem>
+  );
+};
+
+const MenuPreviewTable = ({ obj: cmp }) => {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = React.useState([]);
+  const [contents, setContents] = React.useState([]);
+
+  const toggle = id => {
+    const index = expanded.indexOf(id);
+    const newExpanded = index >= 0 ? [...expanded.slice(0, index), ...expanded.slice(index + 1, expanded.length)] : [...expanded, id];
+    setExpanded(newExpanded);
+  };
+
+  React.useEffect(() => {
+    const menuContents = cmp.menuTabs?.map((menuTab, index) => {
+      const contentData: MenuContentItem[] = menuTab.menus?.map(menu => {
+        const menuType = menu.menuType;
+        switch (menuType) {
+          case MenuType.NEW_TAB_LINK:
+            return { title: menu.label || '', childrenMenus: null };
+          case MenuType.REGISTERED_MENU:
+            return { title: getMenuTitle(menu.kind || '', t), childrenMenus: null };
+          case MenuType.CONTAINER:
+            const childrenMenus = menu.innerMenus?.map(menu => {
+              return menu.type === MenuType.NEW_TAB_LINK ? menu.label : getMenuTitle(menu.kind || '', t);
+            });
+            return { title: getContainerLabel(menu.label, t), childrenMenus };
+          default:
+        }
+      });
+      return <AccordionBlock key={menuTab.name} title={menuTab.name} onToggle={toggle} expanded={expanded} index={index} contentData={contentData} />;
+    });
+    setContents(menuContents);
+  }, [cmp, expanded]);
+
+  return <Accordion>{contents}</Accordion>;
+};
+
+const ClusterMenuPolicyDetails: React.FC<ClusterMenuPolicyDetailsProps> = ({ obj: cmp }) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="co-m-pane__body">
+        <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DETAILS_1', { 0: ResourceLabel(cmp, t) })} />
+        <div className="row">
+          <div className="col-lg-6">
+            <ResourceSummary resource={cmp} />
+          </div>
+        </div>
+      </div>
+      <div className="co-m-pane__body">
+        <SectionHeading text={t('메뉴')} />
+        <MenuPreviewTable obj={cmp} />
+      </div>
+    </>
+  );
+};
+
+const { details, editResource } = navFactory;
+
+export const ClusterMenuPoliciesPage: React.FC<ClusterMenuPolicyPageProps> = props => <ListPage canCreate={true} tableProps={tableProps} kind={kind} {...props} />;
+
+export const ClusterMenuPoliciesDetailsPage: React.FC<ClusterMenuPoliciesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(ClusterMenuPolicyDetails)), editResource()]} />;
+
+type ClusterMenuPolicyDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type ClusterMenuPolicyPageProps = {
+  showTitle?: boolean;
+  namespace?: string;
+  selector?: any;
+};
+
+type ClusterMenuPoliciesDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/hypercloud/cluster-menu-policy.tsx
+++ b/frontend/public/components/hypercloud/cluster-menu-policy.tsx
@@ -182,7 +182,7 @@ const MenuPreviewTable = ({ obj: cmp }) => {
             const childrenMenus = menu.innerMenus?.map(menu => {
               return menu.type === MenuType.NEW_TAB_LINK ? menu.label : getMenuTitle(menu.kind || '', t);
             });
-            return { title: getContainerLabel(menu.label, t), childrenMenus };
+            return { title: getContainerLabel(menu.label, t)?.containerLabel, childrenMenus };
           default:
         }
       });

--- a/frontend/public/components/hypercloud/cluster-template-claim.tsx
+++ b/frontend/public/components/hypercloud/cluster-template-claim.tsx
@@ -122,7 +122,7 @@ const ClusterTemplateClaimTableHeader = (t?: TFunction) => {
     },
     {
       title: t('COMMON:MSG_MAIN_TABLEHEADER_3'),
-      sortFunc: 'clusterTemplateClaimStatusReducer',
+      sortFunc: 'ClusterTemplateClaimReducer',
       transforms: [sortable],
       props: { className: tableColumnClasses[2] },
     },

--- a/frontend/public/components/hypercloud/nav/cluster-dropdown.tsx
+++ b/frontend/public/components/hypercloud/nav/cluster-dropdown.tsx
@@ -84,7 +84,8 @@ const ClusterDropdown_: React.FC<ClusterDropdownProps & StateProps> = ({ setActi
   React.useEffect(() => {
     if (clusters.length == 0 || isClusterDropdownOpen) {
       setLoaded(false);
-      coFetchJSON(`/api/multi-hypercloud/clustermanagers/access?userId=${getId()}${getUserGroup()}`, 'GET')
+      // MEMO : 마스터클러스터용 콜을 할 땐 location.origin 붙여줘야 함.
+      coFetchJSON(`${location.origin}/api/multi-hypercloud/clustermanagers/access?userId=${getId()}${getUserGroup()}`, 'GET')
         .then(result => result.items)
         .then(res => {
           const clusterList: clusterItemProps[] = res.reduce((list, cluster) => {

--- a/frontend/public/components/hypercloud/resource-pages.ts
+++ b/frontend/public/components/hypercloud/resource-pages.ts
@@ -75,6 +75,7 @@ import {
   AWXModel,
   ClusterRegistrationModel,
   ApplicationModel,
+  ClusterMenuPolicyModel,
 } from '../../models';
 
 type ResourceMapKey = GroupVersionKind | string;
@@ -153,7 +154,8 @@ export const hyperCloudDetailsPages = ImmutableMap<ResourceMapKey, ResourceMapVa
   .set(referenceForModel(HelmReleaseModel), () => import('./helm-release' /* webpackChunkName: "helm-release" */).then(m => m.HelmReleaseDetailsPage))
   .set(referenceForModel(AWXModel), () => import('./awx' /* webpackChunkName: "awx" */).then(m => m.AWXsDetailsPage))
   .set(referenceForModel(ClusterRegistrationModel), () => import('./cluster-registration' /* webpackChunkName: "cluster-registration" */).then(m => m.ClusterRegistrationsDetailsPage))
-  .set(referenceForModel(ApplicationModel), () => import('./application' /* webpackChunkName: "application" */).then(m => m.ApplicationsDetailsPage));
+  .set(referenceForModel(ApplicationModel), () => import('./application' /* webpackChunkName: "application" */).then(m => m.ApplicationsDetailsPage))
+  .set(referenceForModel(ClusterMenuPolicyModel), () => import('./cluster-menu-policy' /* webpackChunkName: "cluster-menu-policy" */).then(m => m.ClusterMenuPoliciesDetailsPage));
 
 export const hyperCloudListPages = ImmutableMap<ResourceMapKey, ResourceMapValue>()
   .set(referenceForModel(PodSecurityPolicyModel), () => import('./pod-security-policy' /* webpackChunkName: "pod-security-policy" */).then(m => m.PodSecurityPoliciesPage))
@@ -227,4 +229,5 @@ export const hyperCloudListPages = ImmutableMap<ResourceMapKey, ResourceMapValue
   .set(referenceForModel(HelmReleaseModel), () => import('./helm-release' /* webpackChunkName: "helm-release" */).then(m => m.HelmReleasePage))
   .set(referenceForModel(AWXModel), () => import('./awx' /* webpackChunkName: "awx" */).then(m => m.AWXsPage))
   .set(referenceForModel(ClusterRegistrationModel), () => import('./cluster-registration' /* webpackChunkName: "cluster-registration" */).then(m => m.ClusterRegistrationsPage))
-  .set(referenceForModel(ApplicationModel), () => import('./application' /* webpackChunkName: "application" */).then(m => m.ApplicationsPage));
+  .set(referenceForModel(ApplicationModel), () => import('./application' /* webpackChunkName: "application" */).then(m => m.ApplicationsPage))
+  .set(referenceForModel(ClusterMenuPolicyModel), () => import('./cluster-menu-policy' /* webpackChunkName: "cluster-menu-policy" */).then(m => m.ClusterMenuPoliciesPage));

--- a/frontend/public/components/hypercloud/utils/default-list-component.tsx
+++ b/frontend/public/components/hypercloud/utils/default-list-component.tsx
@@ -53,11 +53,11 @@ const makeTableRow = (row: Rows) => {
 };
 
 export const DefaultListComponent: React.FC<DefaultListComponentProps> = props => {
-  const { header, row } = props.tableProps;
+  const { header, row, customSorts } = props.tableProps;
   const { t } = useTranslation();
   const headerFunc = makeTableHeader(header, t);
   const rowFunc = makeTableRow(row);
-  return <Table {...props} aria-label="Resource List" Header={headerFunc} Row={rowFunc} virtualize />;
+  return <Table {...props} aria-label="Resource List" Header={headerFunc} Row={rowFunc} virtualize customSorts={customSorts} />;
 };
 
 type Header = {
@@ -78,6 +78,7 @@ type Rows = (resource: any, customData?: any) => Row[];
 export type TableProps = {
   header: Header[];
   row: Rows;
+  customSorts?: { [key: string]: any };
 };
 
 type DefaultListComponentProps = {

--- a/frontend/public/components/hypercloud/utils/ingress-utils.ts
+++ b/frontend/public/components/hypercloud/utils/ingress-utils.ts
@@ -1,0 +1,45 @@
+import * as _ from 'lodash-es';
+import { IngressModel } from '@console/internal/models';
+import { Selector } from '@console/internal/module/k8s';
+import { coFetchJSON } from '@console/internal/co-fetch';
+import { selectorToString } from '@console/internal/module/k8s/selector';
+import { initializationForMenu } from '@console/internal/components/hypercloud/utils/menu-utils';
+
+export const DoneMessage = 'done';
+
+export const ingressUrlWithLabelSelector = labelSelector => {
+  const { apiGroup, apiVersion, plural } = IngressModel;
+  const labelSelectorString = selectorToString(labelSelector as Selector);
+  const query = `&${encodeURIComponent('labelSelector')}=${encodeURIComponent(labelSelectorString)}`;
+  return `api/console/apis/${apiGroup}/${apiVersion}/${plural}?${query}`;
+};
+
+const setSingleClusterBasePath = () => {
+  return new Promise((resolve, reject) => {
+    const url = ingressUrlWithLabelSelector({
+      'ingress.tmaxcloud.org/name': 'multicluster',
+    });
+    // MEMO : singleClusterBasePath설정을 위해 필요한 콜은 마스터클러스터 콜이여서 직접 location.origin으로 도메인 설정해줌.
+    // MEMO : (직접적인 https://가 포함된 도메인 설정 없을 경우 co-fetch.js의 coFetchCommon에서 perspective 상태에 따라 도메인을 바꿔줌)
+    coFetchJSON(`${location.origin}/${url}`)
+      .then(res => {
+        const { items } = res;
+        if (items?.length > 0) {
+          const ingress = items[0];
+          const host = ingress.spec?.rules?.[0]?.host;
+          if (!!host) {
+            window.SERVER_FLAGS.singleClusterBasePath = `https://${host}/`;
+          }
+        }
+        resolve(DoneMessage);
+      })
+      .catch(err => {
+        resolve(DoneMessage);
+      });
+  });
+};
+
+export const setUrlFromIngresses = async () => {
+  await setSingleClusterBasePath();
+  await initializationForMenu();
+};

--- a/frontend/public/components/hypercloud/utils/menu-utils.ts
+++ b/frontend/public/components/hypercloud/utils/menu-utils.ts
@@ -108,15 +108,15 @@ export const initializationForMenu = async () => {
   await initializeGrafanaUrl();
 };
 
-export const getMenuTitle = (kind, t: TFunction) => {
+export const getMenuTitle = (kind, t: TFunction): { label: string; type: string } => {
   if (!!modelFor(kind)) {
-    return getLabelTextByKind(kind, t)?.label;
+    return getLabelTextByKind(kind, t);
   } else {
     const menuInfo = CustomMenusMap[kind];
     if (!!menuInfo) {
-      return getLabelTextByDefaultLabel(menuInfo.defaultLabel, t)?.label;
+      return getLabelTextByDefaultLabel(menuInfo.defaultLabel, t);
     } else {
-      return '';
+      return { label: '', type: CUSTOM_LABEL_TYPE };
     }
   }
 };

--- a/frontend/public/components/hypercloud/utils/menu-utils.ts
+++ b/frontend/public/components/hypercloud/utils/menu-utils.ts
@@ -1,9 +1,12 @@
 import * as _ from 'lodash-es';
 import { ClusterMenuPolicyModel, IngressModel } from '@console/internal/models';
-import { k8sList, k8sGet, Selector } from '@console/internal/module/k8s';
+import { k8sList, k8sGet, Selector, modelFor } from '@console/internal/module/k8s';
 import { CMP_PRIMARY_KEY, CustomMenusMap } from '@console/internal/hypercloud/menu/menu-types';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { selectorToString } from '@console/internal/module/k8s/selector';
+import i18next, { TFunction } from 'i18next';
+import { ResourceLabel } from '@console/internal/models/hypercloud/resource-plural';
+import { MenuContainerLabels } from '@console/internal/hypercloud/menu/menu-types';
 
 const ingressUrlWithLabelSelector = labelSelector => {
   const { apiGroup, apiVersion, plural } = IngressModel;
@@ -104,4 +107,32 @@ export const initializationForMenu = async () => {
   await initializeHarborUrl();
   await initializeGitlabUrl();
   await initializeGrafanaUrl();
+};
+
+export const getMenuTitle = (kind, t: TFunction) => {
+  if (!!modelFor(kind)) {
+    return getLabelTextByModel(kind, t);
+  } else {
+    const menuInfo = CustomMenusMap[kind];
+    if (!!menuInfo) {
+      return getLabelTextByDefaultLabel(menuInfo.defaultLabel, t);
+    } else {
+      return '';
+    }
+  }
+};
+
+export const getLabelTextByModel = (kind, t: TFunction) => {
+  const model = modelFor(kind);
+  return ResourceLabel(model, t);
+};
+
+export const getLabelTextByDefaultLabel = (defaultLabel, t: TFunction) => {
+  const i18nExists = i18next.exists(defaultLabel);
+  return i18nExists ? t(defaultLabel) : defaultLabel;
+};
+
+export const getContainerLabel = (label, t: TFunction) => {
+  const labelText = label?.toLowerCase().replace(' ', '') || '';
+  return !!MenuContainerLabels[labelText] ? t(MenuContainerLabels[labelText]) : label;
 };

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -21,8 +21,6 @@ import { setAccessToken, setIdToken } from '../hypercloud/auth';
 import { withTranslation } from 'react-i18next';
 import i18n from 'i18next';
 import { HyperCloudManualLink } from './utils';
-import { CMP_PRIMARY_KEY } from '@console/internal/hypercloud/menu/menu-types';
-import { ClusterMenuPolicyModel } from '@console/internal/models';
 
 const SystemStatusButton = ({ statuspageData, className }) =>
   !_.isEmpty(_.get(statuspageData, 'incidents')) ? (
@@ -45,8 +43,6 @@ class MastheadToolbarContents_ extends React.Component {
       statuspageData: null,
       isKubeAdmin: false,
       showAboutModal: false,
-      adminCmpExists: false,
-      adminCmpName: '',
     };
 
     this._getStatuspageData = this._getStatuspageData.bind(this);
@@ -67,7 +63,6 @@ class MastheadToolbarContents_ extends React.Component {
     this._onAboutModal = this._onAboutModal.bind(this);
     this._closeAboutModal = this._closeAboutModal.bind(this);
     this._tokenRefresh = this._tokenRefresh.bind(this);
-    this._checkCmpResourceExists = this._checkCmpResourceExists.bind(this);
   }
 
   _getStatuspageData(statuspageID) {
@@ -76,25 +71,6 @@ class MastheadToolbarContents_ extends React.Component {
     })
       .then(response => response.json())
       .then(statuspageData => this.setState({ statuspageData }));
-  }
-
-  _checkCmpResourceExists() {
-    k8sList(ClusterMenuPolicyModel, {
-      labelSelector: {
-        [CMP_PRIMARY_KEY]: 'true',
-      },
-    })
-      .then(policies => {
-        if (policies.length > 0) {
-          const policy = policies[0];
-          this.setState({ adminCmpName: policy?.metadata.name, adminCmpExists: true });
-        } else {
-          this.setState({ adminCmpExists: false });
-        }
-      })
-      .catch(err => {
-        this.setState({ adminCmpExists: false });
-      });
   }
 
   _getImportYAMLPath() {
@@ -465,12 +441,8 @@ class MastheadToolbarContents_ extends React.Component {
       });
   };
 
-  componentDidMount() {
-    this._checkCmpResourceExists();
-  }
-
   render() {
-    const { isApplicationLauncherDropdownOpen, isHelpDropdownOpen, showAboutModal, statuspageData, adminCmpExists, adminCmpName } = this.state;
+    const { isApplicationLauncherDropdownOpen, isHelpDropdownOpen, showAboutModal, statuspageData } = this.state;
     const { consoleLinks, drawerToggle, notificationsRead, canAccessNS, keycloak, t } = this.props;
     // TODO: notificatoin 기능 완료 되면 추가하기.
     const alertAccess = false; //canAccessNS && !!window.SERVER_FLAGS.prometheusBaseURL;
@@ -526,13 +498,6 @@ class MastheadToolbarContents_ extends React.Component {
                 <a href={HyperCloudManualLink} target="_blank">
                   <QuestionCircleIcon className="co-masthead-icon" color="white" />
                 </a>
-              </Tooltip>
-            </ToolbarItem>
-            <ToolbarItem>
-              <Tooltip content="Menu Settings" position={TooltipPosition.bottom}>
-                <Link to={adminCmpExists ? `/k8s/cluster/clustermenupolicies/${adminCmpName}/edit` : '/k8s/cluster/clustermenupolicies/~new'} className="pf-c-button pf-m-plain" aria-label="Menu Settings">
-                  <CogIcon className="co-masthead-icon" color="white" />{' '}
-                </Link>
               </Tooltip>
             </ToolbarItem>
           </ToolbarGroup>

--- a/frontend/public/components/nav/_nav-footer.scss
+++ b/frontend/public/components/nav/_nav-footer.scss
@@ -1,0 +1,25 @@
+.hc-nav-footer {
+  width: 100%;
+
+  .hc-settings-button {
+    display: flex;
+    width: 100%;
+    background-color: #213a53;
+    color: $color-pf-black-500;
+    height: 35px;
+    border-radius: 10px 10px 0 0;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    bottom: 0;
+    cursor: pointer;
+
+    &:hover {
+      background-color: #24405c;
+    }
+  }
+
+  .hc-settings-icon {
+    font-size: 15px;
+  }
+}

--- a/frontend/public/components/nav/_nav-footer.scss
+++ b/frontend/public/components/nav/_nav-footer.scss
@@ -1,13 +1,16 @@
 .hc-nav-footer {
   width: 100%;
+  display: flex;
+  justify-content: end;
 
   .hc-settings-button {
     display: flex;
-    width: 100%;
-    background-color: #213a53;
+    width: 20px;
+    height: 20px;
+    margin-bottom: 5px;
+    margin-right: 10px;
     color: $color-pf-black-500;
-    height: 35px;
-    border-radius: 10px 10px 0 0;
+    border-radius: 10px;
     align-items: center;
     justify-content: center;
     position: absolute;

--- a/frontend/public/components/nav/_nav-header.scss
+++ b/frontend/public/components/nav/_nav-header.scss
@@ -1,5 +1,5 @@
 .oc-nav-header {
-  padding: 3px 20px 20px 25px;
+  padding: 3px 20px 10px 25px;
 
   .hc-dropdown__title {
     font-size: 10px;
@@ -22,7 +22,7 @@
     border: 1px solid #ffffff;
     border-radius: 5px;
   }
-  .pf-c-dropdown__menu-item  {
+  .pf-c-dropdown__menu-item {
     padding-left: 7px;
   }
 
@@ -37,10 +37,9 @@
   .pf-c-dropdown__menu-item:hover,
   .pf-c-dropdown__menu-item.pf-m-hover {
     h1 {
-      color: #0066CC;
+      color: #0066cc;
     }
   }
-  
 
   .pf-c-dropdown__toggle {
     font-size: $co-side-nav-font-size;
@@ -62,5 +61,4 @@
       border: none;
     }
   }
-
 }

--- a/frontend/public/components/nav/index.tsx
+++ b/frontend/public/components/nav/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Nav, NavProps, NavList, PageSidebar } from '@patternfly/react-core';
 import PerspectiveNav from './perspective-nav';
 import NavHeader from './nav-header';
+import NavFooter from './nav-footer';
 
 type NavigationProps = {
   onNavSelect: NavProps['onSelect'];
@@ -10,19 +11,22 @@ type NavigationProps = {
   isNavOpen: boolean;
 };
 
-export const Navigation: React.FC<NavigationProps> = React.memo(
-  ({ isNavOpen, onNavSelect, onPerspectiveSelected, onClusterSelected }) => (
-    <PageSidebar
-      nav={
+export const Navigation: React.FC<NavigationProps> = React.memo(({ isNavOpen, onNavSelect, onPerspectiveSelected, onClusterSelected }) => (
+  <PageSidebar
+    nav={
+      <>
         <Nav aria-label="Nav" onSelect={onNavSelect} theme="dark">
-          <NavHeader onPerspectiveSelected={onPerspectiveSelected} onClusterSelected={onClusterSelected} />
-          <NavList>
-            <PerspectiveNav />
-          </NavList>
+          <div className="pf-c-nav__list-container">
+            <NavHeader onPerspectiveSelected={onPerspectiveSelected} onClusterSelected={onClusterSelected} />
+            <NavList>
+              <PerspectiveNav />
+            </NavList>
+          </div>
+          <NavFooter />
         </Nav>
-      }
-      isNavOpen={isNavOpen}
-      theme="dark"
-    />
-  ),
-);
+      </>
+    }
+    isNavOpen={isNavOpen}
+    theme="dark"
+  />
+));

--- a/frontend/public/components/nav/index.tsx
+++ b/frontend/public/components/nav/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 import { Nav, NavProps, NavList, PageSidebar } from '@patternfly/react-core';
 import PerspectiveNav from './perspective-nav';
 import NavHeader from './nav-header';
@@ -9,20 +10,21 @@ type NavigationProps = {
   onPerspectiveSelected: () => void;
   onClusterSelected: () => void;
   isNavOpen: boolean;
+  isSingleClusterPerspective: boolean;
 };
 
-export const Navigation: React.FC<NavigationProps> = React.memo(({ isNavOpen, onNavSelect, onPerspectiveSelected, onClusterSelected }) => (
+export const Navigation: React.FC<NavigationProps> = React.memo(({ isNavOpen, onNavSelect, onPerspectiveSelected, onClusterSelected, isSingleClusterPerspective }) => (
   <PageSidebar
     nav={
       <>
         <Nav aria-label="Nav" onSelect={onNavSelect} theme="dark">
-          <div className="pf-c-nav__list-container">
+          <div className={classNames('pf-c-nav__list-container', { 'without-footer': isSingleClusterPerspective })}>
             <NavHeader onPerspectiveSelected={onPerspectiveSelected} onClusterSelected={onClusterSelected} />
             <NavList>
               <PerspectiveNav />
             </NavList>
           </div>
-          <NavFooter />
+          {!isSingleClusterPerspective && <NavFooter />}
         </Nav>
       </>
     }

--- a/frontend/public/components/nav/menus.tsx
+++ b/frontend/public/components/nav/menus.tsx
@@ -1,16 +1,14 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Translation } from 'react-i18next';
-import i18next, { TFunction, i18n } from 'i18next';
+import { TFunction, i18n } from 'i18next';
 import { modelFor } from '@console/internal/module/k8s';
 import { NavSection } from '@console/internal/components/nav/section';
 import { HrefLink, ResourceNSLink, ResourceClusterLink, NewTabLink, Separator } from '@console/internal/components/nav/items';
 import HyperCloudDefaultMenus from '@console/internal/hypercloud/menu/hc-default-menus';
-import { CustomMenusMap, MenuType, MenuLinkType, MenuContainerLabels } from '@console/internal/hypercloud/menu/menu-types';
+import { CustomMenusMap, MenuType, MenuLinkType, CUSTOM_LABEL_TYPE } from '@console/internal/hypercloud/menu/menu-types';
 import { PerspectiveType } from '@console/internal/hypercloud/perspectives';
-import { ResourceLabel, getI18nInfo } from '@console/internal/models/hypercloud/resource-plural';
-
-const en = i18next.getFixedT('en');
+import { getContainerLabel, getLabelTextByDefaultLabel, getLabelTextByKind } from '@console/internal/components/hypercloud/utils/menu-utils';
 
 type MenuData = {
   menuType: MenuType;
@@ -48,21 +46,13 @@ export const basicMenusFactory = perspective => {
           {menus?.map((menuData, index) => {
             switch (menuData.menuType) {
               case MenuType.CONTAINER: {
-                const i18nExist = i18next.exists(menuData.label);
-                let containerLabel = '';
-                let type = '';
-                if (i18nExist) {
-                  containerLabel = t(menuData.label);
-                  type = en(menuData.label);
-                } else {
-                  //user가 추가한 menu이거나 i18n키가 없는경우
-                  containerLabel = menuData.label;
-                  type = '@@customlabel@@';
-                }
+                const { label: containerLabel, type } = getLabelTextByDefaultLabel(menuData.label, t);
                 return (
                   <NavSection title={containerLabel} key={containerLabel} type={type}>
                     {menuData.innerMenus?.map(innerMenuKind => {
-                      return generateMenu(perspective, innerMenuKind, true, t, i18n);
+                      // MEMO : generateMenu()에서 data를 동일하게 object형식으로 받게하기 위해 정제해줌. (kind와 menuType모두 innerMenuKind로 값 동일함)
+                      const d = { kind: innerMenuKind, menuType: innerMenuKind };
+                      return generateMenu(perspective, d, true, t, i18n);
                     })}
                   </NavSection>
                 );
@@ -92,18 +82,7 @@ export const dynamicMenusFactory = (perspective, data) => {
           {data.menus?.map((menuData: MenuData, index) => {
             switch (menuData.menuType) {
               case MenuType.CONTAINER: {
-                const labelText = menuData.label?.toLowerCase().replace(' ', '') || '';
-                const containerKeyOrLabel = !!MenuContainerLabels[labelText] ? t(MenuContainerLabels[labelText]) : menuData.label;
-                const i18nExist = i18next.exists(containerKeyOrLabel);
-                let containerLabel = '';
-                let type = '';
-                if (i18nExist) {
-                  containerLabel = t(labelText);
-                  type = en(labelText);
-                } else {
-                  containerLabel = labelText;
-                  type = '@@customlabel@@';
-                }
+                const { containerLabel, type } = getContainerLabel(menuData.label, t);
                 return (
                   <NavSection title={containerLabel || ''} key={containerLabel} type={type}>
                     {menuData.innerMenus?.map(innerMenuData => {
@@ -145,15 +124,13 @@ const getMenuComponent = (menuInfo, labelText) => {
   }
 };
 
-const generateMenu = (perspective, data, isInnerMenu, t: TFunction, i18n: i18n) => {
-  // MEMO : BasicMenus는 string으로 들어오고, DynamicMenus는 object형태로 데이타가 들어옴.
-  const kind = typeof data === 'string' ? data : data.kind || '';
-  // MEMO : data가 string타입일 땐 data값이 kind와 menuType으로 동일함.
-  const menuType = typeof data === 'string' ? kind : data.menuType || '';
+const generateMenu = (perspective, data: any, isInnerMenu, t: TFunction, i18n: i18n) => {
+  const kind = data.kind || '';
+  const menuType = data.menuType || '';
   if (isInnerMenu && menuType === MenuType.SEPERATOR) {
     return <Separator name="seperator" />;
   } else if (menuType === MenuType.NEW_TAB_LINK) {
-    const label = data.label || 'empty';
+    const label = data.label || 'label empty';
     const menuInfo = {
       visible: true,
       type: MenuLinkType.NewTabLink,
@@ -164,17 +141,14 @@ const generateMenu = (perspective, data, isInnerMenu, t: TFunction, i18n: i18n) 
     return isInnerMenu ? (
       getMenuComponent(menuInfo, label)
     ) : (
-      <NavSection title={label} isSingleChild={true} type="@@customlabel@@">
+      <NavSection title={label} isSingleChild={true} type={CUSTOM_LABEL_TYPE}>
         {getMenuComponent(menuInfo, label)}
       </NavSection>
     );
   } else {
     if (!!modelFor(kind)) {
+      const { label, type } = getLabelTextByKind(kind, t);
       const model = modelFor(kind);
-
-      const label = ResourceLabel(model, t);
-      const key = getI18nInfo(model)?.label;
-      const type = i18next.exists(key) ? en(key) : '@@customlabel@@';
       const modelMenuInfo = model.menuInfo;
 
       if (!modelMenuInfo || !modelMenuInfo.visible || (perspective !== PerspectiveType.MULTI && modelMenuInfo.isMultiOnly === true)) {
@@ -197,9 +171,7 @@ const generateMenu = (perspective, data, isInnerMenu, t: TFunction, i18n: i18n) 
       if (!menuInfo || !menuInfo.visible) {
         return <></>;
       } else {
-        const i18nExists = i18n.exists(menuInfo.defaultLabel);
-        const label = i18nExists ? t(menuInfo.defaultLabel) : menuInfo.defaultLabel;
-        const type = i18nExists ? en(menuInfo.defaultLabel) : '@@customlabel@@';
+        const { label, type } = getLabelTextByDefaultLabel(menuInfo.defaultLabel, t);
         return isInnerMenu ? (
           getMenuComponent(menuInfo, label)
         ) : (

--- a/frontend/public/components/nav/nav-footer.tsx
+++ b/frontend/public/components/nav/nav-footer.tsx
@@ -6,11 +6,9 @@ import { CogIcon } from '@patternfly/react-icons';
 const NavFooter = props => {
   return (
     <div className="hc-nav-footer">
-      <Tooltip content="Menu Settings" position={TooltipPosition.bottom}>
+      <Tooltip content="Menu Settings" position={TooltipPosition.top}>
         <Link to="/k8s/cluster/clustermenupolicies" className="hc-settings-button" aria-label="Menu Settings">
-          {/* <div className="hc-settings-button"> */}
-          <CogIcon className="hc-settings-icon" color="white" />
-          {/* </div> */}
+          <CogIcon className="hc-settings-icon" color="#F9F9F9" />
         </Link>
       </Tooltip>
     </div>

--- a/frontend/public/components/nav/nav-footer.tsx
+++ b/frontend/public/components/nav/nav-footer.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { CogIcon } from '@patternfly/react-icons';
+
+const NavFooter = props => {
+  return (
+    <div className="hc-nav-footer">
+      <Tooltip content="Menu Settings" position={TooltipPosition.bottom}>
+        <Link to="/k8s/cluster/clustermenupolicies" className="hc-settings-button" aria-label="Menu Settings">
+          {/* <div className="hc-settings-button"> */}
+          <CogIcon className="hc-settings-icon" color="white" />
+          {/* </div> */}
+        </Link>
+      </Tooltip>
+    </div>
+  );
+};
+
+export default NavFooter;

--- a/frontend/public/components/nav/perspective-nav.tsx
+++ b/frontend/public/components/nav/perspective-nav.tsx
@@ -4,13 +4,11 @@ import * as _ from 'lodash-es';
 import { RootState } from '../../redux';
 import { setPinnedResources } from '../../actions/ui';
 import { getActivePerspective, getPinnedResources } from '../../reducers/ui';
-import { k8sList } from '@console/internal/module/k8s';
-import { ClusterMenuPolicyModel } from '@console/internal/models';
+import { getCmpListFetchUrl } from '@console/internal/components/hypercloud/utils/menu-utils';
+import { coFetchJSON } from '@console/internal/co-fetch';
 import { dynamicMenusFactory, basicMenusFactory } from './menus';
 import './_perspective-nav.scss';
 import { PerspectiveType } from '../../hypercloud/perspectives';
-import { CMP_PRIMARY_KEY } from '@console/internal/hypercloud/menu/menu-types';
-
 type StateProps = {
   perspective: string;
   pinnedResources: string[];
@@ -24,15 +22,11 @@ const PerspectiveNav: React.FC<StateProps & DispatchProps> = ({ perspective }) =
   const [cmp, setCmp] = React.useState(null);
 
   React.useEffect(() => {
-    k8sList(ClusterMenuPolicyModel, {
-      labelSelector: {
-        [CMP_PRIMARY_KEY]: 'true',
-      },
-    })
-      .then(policies => {
-        if (policies.length > 0) {
+    coFetchJSON(getCmpListFetchUrl())
+      .then(res => {
+        if (res?.items?.length > 0) {
           // MEMO : primary=true 레이블 가진 리소스 중 첫번째 리소스내용만 적용되도록 구현.
-          setCmp(policies[0]);
+          setCmp(res.items[0]);
         } else {
           setCmp({ tabs: [] });
         }

--- a/frontend/public/declarations.d.ts
+++ b/frontend/public/declarations.d.ts
@@ -43,6 +43,7 @@ declare interface Window {
     KeycloakAuthURL: string;
     KeycloakRealm: string;
     gitlabURL: string;
+    singleClusterBasePath: string;
   };
   windowError?: boolean | string;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;

--- a/frontend/public/hypercloud/menu/MenuIcon.tsx
+++ b/frontend/public/hypercloud/menu/MenuIcon.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import * as HomeIcon from '@console/internal/imgs/hypercloud/lnb/filled/home_filled.svg';
+import * as WorkloadIcon from '@console/internal/imgs/hypercloud/lnb/filled/workload_filled.svg';
+import * as HelmIcon from '@console/internal/imgs/hypercloud/lnb/filled/helm_filled_lnb.svg';
+import * as NetworkIcon from '@console/internal/imgs/hypercloud/lnb/filled/network_filled.svg';
+import * as StorageIcon from '@console/internal/imgs/hypercloud/lnb/filled/storage_filled.svg';
+import * as ManagementIcon from '@console/internal/imgs/hypercloud/lnb/filled/management_filled.svg';
+import * as HostIcon from '@console/internal/imgs/hypercloud/lnb/filled/host_filled.svg';
+import * as AuthenticationIcon from '@console/internal/imgs/hypercloud/lnb/filled/authentication_authorization_filled.svg';
+import * as AddIcon from '@console/internal/imgs/hypercloud/lnb/filled/add_filled.svg';
+import * as TopologyIcon from '@console/internal/imgs/hypercloud/lnb/filled/topology_filled.svg';
+import * as ServiceCatalogIcon from '@console/internal/imgs/hypercloud/lnb/filled/service_catalog_filled.svg';
+import * as ServiceMeshIcon from '@console/internal/imgs/hypercloud/lnb/filled/service_mesh_filled.svg';
+import * as CiCdIcon from '@console/internal/imgs/hypercloud/lnb/filled/ci_cd_filled.svg';
+import * as AiDevOpsIcon from '@console/internal/imgs/hypercloud/lnb/filled/ai_devops_filled.svg';
+import * as ImageIcon from '@console/internal/imgs/hypercloud/lnb/filled/image_filled.svg';
+import * as ClusterIcon from '@console/internal/imgs/hypercloud/lnb/filled/cluster_filled.svg';
+import * as TerraformClaimIcon from '@console/internal/imgs/hypercloud/lnb/filled/terraform_claim_filled.svg';
+import * as FederationIcon from '@console/internal/imgs/hypercloud/lnb/filled/ferderation_filled.svg';
+import * as AnsibleIcon from '@console/internal/imgs/hypercloud/lnb/filled/ansible_filled_lnb.svg';
+
+const MenuIconContainer = (props: MenuIconContainerProps) => {
+  const { icon, title } = props;
+  return (
+    <div style={{ display: 'inline-block', width: 160, color: 'black', fontWeight: 'bold', fontSize: '14px' }}>
+      {icon && <img className="font-icon hc-menu-preview-icon" src={icon} />}
+      <span>{title}</span>
+    </div>
+  );
+};
+
+export const MenuIconTitle = (props: MenuIconTitleProps) => {
+  const { type, title } = props;
+  const prettyType = type
+    .toLowerCase()
+    .replace(' ', '_')
+    .replace('/', '_');
+
+  switch (prettyType) {
+    case 'home':
+      return <MenuIconContainer title={title} icon={HomeIcon} />;
+    case 'workload':
+      return <MenuIconContainer title={title} icon={WorkloadIcon} />;
+    case 'helm':
+      return <MenuIconContainer title={title} icon={HelmIcon} />;
+    case 'networking':
+      return <MenuIconContainer title={title} icon={NetworkIcon} />;
+    case 'storage':
+      return <MenuIconContainer title={title} icon={StorageIcon} />;
+    case 'administration':
+      return <MenuIconContainer title={title} icon={ManagementIcon} />;
+    case 'hosts':
+      return <MenuIconContainer title={title} icon={HostIcon} />;
+    case 'authentications':
+      return <MenuIconContainer title={title} icon={AuthenticationIcon} />;
+    case 'add':
+      return <MenuIconContainer title={title} icon={AddIcon} />;
+    case 'topology':
+      return <MenuIconContainer title={title} icon={TopologyIcon} />;
+    case 'service_catalogs':
+      return <MenuIconContainer title={title} icon={ServiceCatalogIcon} />;
+    case 'service_mesh':
+      return <MenuIconContainer title={title} icon={ServiceMeshIcon} />;
+    case 'ci_cd':
+      return <MenuIconContainer title={title} icon={CiCdIcon} />;
+    case 'ai_devops':
+      return <MenuIconContainer title={title} icon={AiDevOpsIcon} />;
+    case 'image':
+      return <MenuIconContainer title={title} icon={ImageIcon} />;
+    case 'cluster':
+      return <MenuIconContainer title={title} icon={ClusterIcon} />;
+    case 'terraform_claim':
+      return <MenuIconContainer title={title} icon={TerraformClaimIcon} />;
+    case 'federation':
+      return <MenuIconContainer title={title} icon={FederationIcon} />;
+    case 'ansible':
+      return <MenuIconContainer title={title} icon={AnsibleIcon} />;
+    default:
+      // TODO : defualt 아이콘 발행되면 교체하기
+      return <MenuIconContainer title={title} icon={ManagementIcon} />;
+  }
+};
+
+type MenuIconContainerProps = {
+  icon: any;
+  title: string;
+};
+
+type MenuIconTitleProps = {
+  type: string;
+  title: string;
+};

--- a/frontend/public/hypercloud/menu/menu-types.tsx
+++ b/frontend/public/hypercloud/menu/menu-types.tsx
@@ -1,6 +1,7 @@
 import startsWith from './starts-with';
 
 export const CMP_PRIMARY_KEY = 'primary';
+export const CUSTOM_LABEL_TYPE = '@@customlabel@@';
 
 export enum MenuType {
   CONTAINER = 'CONTAINER',

--- a/frontend/public/hypercloud/perspectives.tsx
+++ b/frontend/public/hypercloud/perspectives.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { CogsIcon } from '@patternfly/react-icons';
 import { Perspective } from '@console/plugin-sdk';
+import { getActivePerspective, getActiveCluster } from '@console/internal/actions/ui';
 import { TFunction } from 'i18next';
 import * as MultiClusterIcon from '@console/internal/imgs/hypercloud/lnb/multi_cluster.svg';
 import * as MasterClusterIcon from '@console/internal/imgs/hypercloud/lnb/master_cluster.svg';
@@ -9,7 +10,7 @@ import * as DeveloperIcon from '@console/internal/imgs/hypercloud/lnb/developer.
 import * as SelectedMultiClusterIcon from '@console/internal/imgs/hypercloud/lnb/filled/multi_cluster_filled.svg';
 import * as SelectedMasterClusterIcon from '@console/internal/imgs/hypercloud/lnb/filled/master_cluster_filled.svg';
 import * as SelectedSingleClusterIcon from '@console/internal/imgs/hypercloud/lnb/filled/single_cluster_filled.svg';
-import * as SelectedDeveloperIcon from '@console/internal/imgs/hypercloud/lnb/filled/developer_filled.svg'
+import * as SelectedDeveloperIcon from '@console/internal/imgs/hypercloud/lnb/filled/developer_filled.svg';
 
 export enum PerspectiveType {
   MASTER = 'MASTER',
@@ -19,89 +20,96 @@ export enum PerspectiveType {
   CUSTOM = 'CUSTOM',
 }
 
+export const isSingleClusterPerspective = () => {
+  return window.SERVER_FLAGS.McMode && getActivePerspective() == PerspectiveType.SINGLE;
+};
+export const getSingleClusterFullBasePath = () => {
+  return `${window.SERVER_FLAGS.singleClusterBasePath}api/${getActiveCluster()}`;
+};
+
 /* 임시 */
 // TODO:  싱글 클러스터 증가시 동적 생성하는 방법 확인
 //        getK8sLandingPageURL, getImportRedirectURL 하는 상황 파악 및 수정
 export const getPerspectives: (t?: TFunction) => Perspective[] = (t?: TFunction) => {
   const perspectives: Perspective[] = window.SERVER_FLAGS.McMode
     ? [
-      {
-        type: 'Perspective',
-        properties: {
-          id: PerspectiveType.MULTI,
-          name: t ? t('COMMON:MSG_LNB_MENU_CONSOLE_LIST_2') : 'Multi-Cluster',
-          icon: <img src={MultiClusterIcon} className="font-icon co-console-dropdowntoggle-icon" />,
-          selectedIcon: <img src={SelectedMultiClusterIcon} className="font-icon" />,
-          default: true,
-          getLandingPageURL: flags => '/k8s/all-namespaces/clustermanagers',
-          getK8sLandingPageURL: flags => '/k8s/all-namespaces/clustermanagers',
-          getImportRedirectURL: project => `/k8s/all-namespaces/projects/${project}/workloads`,
+        {
+          type: 'Perspective',
+          properties: {
+            id: PerspectiveType.MULTI,
+            name: t ? t('COMMON:MSG_LNB_MENU_CONSOLE_LIST_2') : 'Multi-Cluster',
+            icon: <img src={MultiClusterIcon} className="font-icon co-console-dropdowntoggle-icon" />,
+            selectedIcon: <img src={SelectedMultiClusterIcon} className="font-icon" />,
+            default: true,
+            getLandingPageURL: flags => '/k8s/all-namespaces/clustermanagers',
+            getK8sLandingPageURL: flags => '/k8s/all-namespaces/clustermanagers',
+            getImportRedirectURL: project => `/k8s/all-namespaces/projects/${project}/workloads`,
+          },
         },
-      },
-      {
-        type: 'Perspective',
-        properties: {
-          id: PerspectiveType.MASTER,
-          name: t ? t('COMMON:MSG_LNB_MENU_CONSOLE_LIST_3') : 'Master-Cluster',
-          icon: <img src={MasterClusterIcon} className="font-icon co-console-dropdowntoggle-icon" />,
-          selectedIcon: <img src={SelectedMasterClusterIcon} className="font-icon" />,
-          getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/master/dashboards' : '/welcome'),
-          getK8sLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/master/dashboards' : '/welcome'),
-          getImportRedirectURL: project => `/k8s/cluster/projects/${project}/workloads`,
+        {
+          type: 'Perspective',
+          properties: {
+            id: PerspectiveType.MASTER,
+            name: t ? t('COMMON:MSG_LNB_MENU_CONSOLE_LIST_3') : 'Master-Cluster',
+            icon: <img src={MasterClusterIcon} className="font-icon co-console-dropdowntoggle-icon" />,
+            selectedIcon: <img src={SelectedMasterClusterIcon} className="font-icon" />,
+            getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/master/dashboards' : '/welcome'),
+            getK8sLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/master/dashboards' : '/welcome'),
+            getImportRedirectURL: project => `/k8s/cluster/projects/${project}/workloads`,
+          },
         },
-      },
-      {
-        type: 'Perspective',
-        properties: {
-          id: PerspectiveType.SINGLE,
-          name: t ? t('COMMON:MSG_LNB_MENU_CONSOLE_LIST_1') : 'Single-Cluster',
-          icon: <img src={SingleClusterIcon} className="font-icon co-console-dropdowntoggle-icon" />,
-          selectedIcon: <img src={SelectedSingleClusterIcon} className="font-icon" />,
-          getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/single/dashboards' : '/welcome'),
-          getK8sLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/single/dashboards' : '/welcome'),
-          getImportRedirectURL: project => `/k8s/cluster/projects/${project}/workloads`,
+        {
+          type: 'Perspective',
+          properties: {
+            id: PerspectiveType.SINGLE,
+            name: t ? t('COMMON:MSG_LNB_MENU_CONSOLE_LIST_1') : 'Single-Cluster',
+            icon: <img src={SingleClusterIcon} className="font-icon co-console-dropdowntoggle-icon" />,
+            selectedIcon: <img src={SelectedSingleClusterIcon} className="font-icon" />,
+            getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/single/dashboards' : '/welcome'),
+            getK8sLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/single/dashboards' : '/welcome'),
+            getImportRedirectURL: project => `/k8s/cluster/projects/${project}/workloads`,
+          },
         },
-      },
-      {
-        type: 'Perspective',
-        properties: {
-          id: PerspectiveType.DEVELOPER,
-          name: t ? t('COMMON:MSG_DETAILS_TABACCESSPERMISSIONS_RADIOBUTTON_2') : 'Developer', // 임시. 스트링 나오면 재적용 필요
-          icon: <img src={DeveloperIcon} className="font-icon co-console-dropdowntoggle-icon" />,
-          selectedIcon: <img src={SelectedDeveloperIcon} className="font-icon" />,
-          getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/developer/add' : '/welcome'),
-          getK8sLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/developer/add' : '/welcome'),
-          getImportRedirectURL: project => `/k8s/cluster/projects/${project}/workloads`,
+        {
+          type: 'Perspective',
+          properties: {
+            id: PerspectiveType.DEVELOPER,
+            name: t ? t('COMMON:MSG_DETAILS_TABACCESSPERMISSIONS_RADIOBUTTON_2') : 'Developer', // 임시. 스트링 나오면 재적용 필요
+            icon: <img src={DeveloperIcon} className="font-icon co-console-dropdowntoggle-icon" />,
+            selectedIcon: <img src={SelectedDeveloperIcon} className="font-icon" />,
+            getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/developer/add' : '/welcome'),
+            getK8sLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/developer/add' : '/welcome'),
+            getImportRedirectURL: project => `/k8s/cluster/projects/${project}/workloads`,
+          },
         },
-      },
-    ]
+      ]
     : [
-      {
-        type: 'Perspective',
-        properties: {
-          id: PerspectiveType.MASTER,
-          name: t ? t('COMMON:MSG_LNB_MENU_CONSOLE_LIST_3') : 'Master-Cluster',
-          icon: <img src={MasterClusterIcon} className="font-icon co-console-dropdowntoggle-icon" />,
-          selectedIcon: <img src={SelectedMasterClusterIcon} className="font-icon" />,
-          default: true,
-          getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/master/dashboards' : '/welcome'),
-          getK8sLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/master/dashboards' : '/welcome'),
-          getImportRedirectURL: project => `/k8s/cluster/projects/${project}/workloads`,
+        {
+          type: 'Perspective',
+          properties: {
+            id: PerspectiveType.MASTER,
+            name: t ? t('COMMON:MSG_LNB_MENU_CONSOLE_LIST_3') : 'Master-Cluster',
+            icon: <img src={MasterClusterIcon} className="font-icon co-console-dropdowntoggle-icon" />,
+            selectedIcon: <img src={SelectedMasterClusterIcon} className="font-icon" />,
+            default: true,
+            getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/master/dashboards' : '/welcome'),
+            getK8sLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/master/dashboards' : '/welcome'),
+            getImportRedirectURL: project => `/k8s/cluster/projects/${project}/workloads`,
+          },
         },
-      },
-      {
-        type: 'Perspective',
-        properties: {
-          id: PerspectiveType.DEVELOPER,
-          name: t ? t('COMMON:MSG_DETAILS_TABACCESSPERMISSIONS_RADIOBUTTON_2') : 'Developer', // 임시. 스트링 나오면 재적용 필요
-          icon: <img src={DeveloperIcon} className="font-icon co-console-dropdowntoggle-icon" />,
-          selectedIcon: <img src={SelectedDeveloperIcon} className="font-icon" />,
-          getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/developer/add' : '/welcome'),
-          getK8sLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/developer/add' : '/welcome'),
-          getImportRedirectURL: project => `/k8s/cluster/projects/${project}/workloads`,
+        {
+          type: 'Perspective',
+          properties: {
+            id: PerspectiveType.DEVELOPER,
+            name: t ? t('COMMON:MSG_DETAILS_TABACCESSPERMISSIONS_RADIOBUTTON_2') : 'Developer', // 임시. 스트링 나오면 재적용 필요
+            icon: <img src={DeveloperIcon} className="font-icon co-console-dropdowntoggle-icon" />,
+            selectedIcon: <img src={SelectedDeveloperIcon} className="font-icon" />,
+            getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/developer/add' : '/welcome'),
+            getK8sLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/developer/add' : '/welcome'),
+            getImportRedirectURL: project => `/k8s/cluster/projects/${project}/workloads`,
+          },
         },
-      },
-    ];
+      ];
 
   if (window.SERVER_FLAGS.showCustomPerspective === undefined || window.SERVER_FLAGS.showCustomPerspective === true) {
     perspectives.push({

--- a/frontend/public/hypercloud/perspectives.tsx
+++ b/frontend/public/hypercloud/perspectives.tsx
@@ -20,6 +20,14 @@ export enum PerspectiveType {
   CUSTOM = 'CUSTOM',
 }
 
+export const PerspectiveLabelKeys = {
+  [PerspectiveType.MASTER]: 'COMMON:MSG_LNB_MENU_CONSOLE_LIST_3',
+  [PerspectiveType.MULTI]: 'COMMON:MSG_LNB_MENU_CONSOLE_LIST_2',
+  [PerspectiveType.SINGLE]: 'COMMON:MSG_LNB_MENU_CONSOLE_LIST_1',
+  [PerspectiveType.DEVELOPER]: 'COMMON:MSG_DETAILS_TABACCESSPERMISSIONS_RADIOBUTTON_2',
+  [PerspectiveType.CUSTOM]: 'CUSTOM',
+};
+
 export const isSingleClusterPerspective = () => {
   return window.SERVER_FLAGS.McMode && getActivePerspective() == PerspectiveType.SINGLE;
 };
@@ -37,7 +45,7 @@ export const getPerspectives: (t?: TFunction) => Perspective[] = (t?: TFunction)
           type: 'Perspective',
           properties: {
             id: PerspectiveType.MULTI,
-            name: t ? t('COMMON:MSG_LNB_MENU_CONSOLE_LIST_2') : 'Multi-Cluster',
+            name: t ? t(PerspectiveLabelKeys[PerspectiveType.MULTI]) : 'Multi-Cluster',
             icon: <img src={MultiClusterIcon} className="font-icon co-console-dropdowntoggle-icon" />,
             selectedIcon: <img src={SelectedMultiClusterIcon} className="font-icon" />,
             default: true,
@@ -50,7 +58,7 @@ export const getPerspectives: (t?: TFunction) => Perspective[] = (t?: TFunction)
           type: 'Perspective',
           properties: {
             id: PerspectiveType.MASTER,
-            name: t ? t('COMMON:MSG_LNB_MENU_CONSOLE_LIST_3') : 'Master-Cluster',
+            name: t ? t(PerspectiveLabelKeys[PerspectiveType.MASTER]) : 'Master-Cluster',
             icon: <img src={MasterClusterIcon} className="font-icon co-console-dropdowntoggle-icon" />,
             selectedIcon: <img src={SelectedMasterClusterIcon} className="font-icon" />,
             getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/master/dashboards' : '/welcome'),
@@ -62,7 +70,7 @@ export const getPerspectives: (t?: TFunction) => Perspective[] = (t?: TFunction)
           type: 'Perspective',
           properties: {
             id: PerspectiveType.SINGLE,
-            name: t ? t('COMMON:MSG_LNB_MENU_CONSOLE_LIST_1') : 'Single-Cluster',
+            name: t ? t(PerspectiveLabelKeys[PerspectiveType.SINGLE]) : 'Single-Cluster',
             icon: <img src={SingleClusterIcon} className="font-icon co-console-dropdowntoggle-icon" />,
             selectedIcon: <img src={SelectedSingleClusterIcon} className="font-icon" />,
             getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/single/dashboards' : '/welcome'),
@@ -74,7 +82,7 @@ export const getPerspectives: (t?: TFunction) => Perspective[] = (t?: TFunction)
           type: 'Perspective',
           properties: {
             id: PerspectiveType.DEVELOPER,
-            name: t ? t('COMMON:MSG_DETAILS_TABACCESSPERMISSIONS_RADIOBUTTON_2') : 'Developer', // 임시. 스트링 나오면 재적용 필요
+            name: t ? t(PerspectiveLabelKeys[PerspectiveType.DEVELOPER]) : 'Developer', // 임시. 스트링 나오면 재적용 필요
             icon: <img src={DeveloperIcon} className="font-icon co-console-dropdowntoggle-icon" />,
             selectedIcon: <img src={SelectedDeveloperIcon} className="font-icon" />,
             getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/developer/add' : '/welcome'),
@@ -88,7 +96,7 @@ export const getPerspectives: (t?: TFunction) => Perspective[] = (t?: TFunction)
           type: 'Perspective',
           properties: {
             id: PerspectiveType.MASTER,
-            name: t ? t('COMMON:MSG_LNB_MENU_CONSOLE_LIST_3') : 'Master-Cluster',
+            name: t ? t(PerspectiveLabelKeys[PerspectiveType.MASTER]) : 'Master-Cluster',
             icon: <img src={MasterClusterIcon} className="font-icon co-console-dropdowntoggle-icon" />,
             selectedIcon: <img src={SelectedMasterClusterIcon} className="font-icon" />,
             default: true,
@@ -101,7 +109,7 @@ export const getPerspectives: (t?: TFunction) => Perspective[] = (t?: TFunction)
           type: 'Perspective',
           properties: {
             id: PerspectiveType.DEVELOPER,
-            name: t ? t('COMMON:MSG_DETAILS_TABACCESSPERMISSIONS_RADIOBUTTON_2') : 'Developer', // 임시. 스트링 나오면 재적용 필요
+            name: t ? t(PerspectiveLabelKeys[PerspectiveType.DEVELOPER]) : 'Developer', // 임시. 스트링 나오면 재적용 필요
             icon: <img src={DeveloperIcon} className="font-icon co-console-dropdowntoggle-icon" />,
             selectedIcon: <img src={SelectedDeveloperIcon} className="font-icon" />,
             getLandingPageURL: flags => (localStorage.getItem('flag/first-time-login') ? '/developer/add' : '/welcome'),

--- a/frontend/public/module/k8s/resource.js
+++ b/frontend/public/module/k8s/resource.js
@@ -3,14 +3,15 @@ import { coFetchJSON } from '../../co-fetch';
 import { k8sBasePath, multiClusterBasePath } from './k8s';
 import { selectorToString } from './selector';
 import { WSFactory } from '../ws-factory';
-import { PerspectiveType } from '@console/internal/hypercloud/perspectives';
+import { PerspectiveType, isSingleClusterPerspective, getSingleClusterFullBasePath } from '@console/internal/hypercloud/perspectives';
 import { getActivePerspective, getActiveCluster } from '../../actions/ui';
 import { getId, getUserGroup } from '../../hypercloud/auth';
 import { resourceSchemaBasedMenuMap } from '../../components/hypercloud/form'
 
+
 export const getDynamicProxyPath = (cluster) => {
-  if (window.SERVER_FLAGS.McMode && getActivePerspective() == PerspectiveType.SINGLE) {
-    return `${window.SERVER_FLAGS.basePath}api/${getActiveCluster()}`;
+  if (isSingleClusterPerspective()) {
+    return getSingleClusterFullBasePath();
   } else if (cluster) {
     return `${window.SERVER_FLAGS.basePath}api/${cluster}`;
   } else {
@@ -45,8 +46,8 @@ const getClusterAPIPath = ({ apiGroup = 'core', apiVersion}, cluster)
   const isLegacy = apiGroup === 'core' && apiVersion === 'v1';
   let p = multiClusterBasePath;
 
-  if (window.SERVER_FLAGS.McMode && getActivePerspective() == PerspectiveType.SINGLE) {
-    p = `${window.SERVER_FLAGS.basePath}api/${getActiveCluster()}`;
+  if (isSingleClusterPerspective()) {
+    p = getSingleClusterFullBasePath();
   } else if (cluster) {
     p = `${window.SERVER_FLAGS.basePath}api/${cluster}`;
   }
@@ -137,7 +138,11 @@ const isNamespaceClaim = (model) => {
 
 const resourceNamespaceURL = (model) => {
   const path = isNamespace(model) ? 'namespace' : 'namespaceClaim';
-  return `${document.location.origin}/api/hypercloud/${path}?userId=${getId()}${getUserGroup()}`;
+  if (isSingleClusterPerspective()) {
+    return `${getSingleClusterFullBasePath()}/hypercloud/${path}?userId=${getId()}${getUserGroup()}`;
+  } else {
+    return `${document.location.origin}/api/hypercloud/${path}?userId=${getId()}${getUserGroup()}`;
+  }
 }
 
 export const watchURL = (kind, options) => {

--- a/frontend/public/module/ws-factory.js
+++ b/frontend/public/module/ws-factory.js
@@ -5,9 +5,14 @@
  */
 /* eslint-disable no-console */
 import { getIdToken } from '../hypercloud/auth';
+import { PerspectiveType } from '@console/internal/hypercloud/perspectives';
+import { getActivePerspective, getActiveCluster } from '../actions/ui';
+import { isSingleClusterPerspective } from '@console/internal/hypercloud/perspectives';
 
 function createURL(host, path) {
   let url;
+
+  path = path.replace('https://', '').replace('http://', '');
 
   if (host === 'auto') {
     if (location.protocol === 'https:') {
@@ -15,9 +20,17 @@ function createURL(host, path) {
     } else {
       url = 'ws://';
     }
-    url += location.host;
+    if (isSingleClusterPerspective()) {
+      // MEMO : SingleCluster일 경우 path로 들어오는 window.SERVER_FLAGS.singleClusterBasePath에 도멘인 주소 들어가있어서 별도 처리 해주지 않음.
+    } else {
+      url += location.host;
+    }
   } else {
-    url = host;
+    if (isSingleClusterPerspective()) {
+      // MEMO : SingleCluster일 경우 path로 들어오는 window.SERVER_FLAGS.singleClusterBasePath에 도멘인 주소 들어가있어서 별도 처리 해주지 않음.
+    } else {
+      url = host;
+    }
   }
 
   if (path) {
@@ -30,7 +43,6 @@ function createURL(host, path) {
     } else {
       url += path;
     }
-    // url += path;
   }
 
   return url;

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -106,6 +106,7 @@
 @import 'components/dashboard/project-dashboard/activity-card';
 
 @import 'components/nav/nav-header';
+@import 'components/nav/nav-footer';
 
 @import 'components/hypercloud/utils/dropdown';
 @import 'components/hypercloud/utils/resource-dropdown';

--- a/frontend/public/style/_icons.scss
+++ b/frontend/public/style/_icons.scss
@@ -58,7 +58,12 @@
   margin-right: 2px;
 }
 
+.hc-menu-preview-icon {
+  margin-top: -3px;
+  margin-right: 8px;
+  filter: invert(38%) sepia(2%) saturate(18%) hue-rotate(31deg) brightness(98%) contrast(86%);
+}
 
-.co-console-dropdowntoggle-icon{
+.co-console-dropdowntoggle-icon {
   filter: invert(57%) sepia(12%) saturate(492%) hue-rotate(169deg) brightness(90%) contrast(86%);
 }

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -282,6 +282,7 @@ h6 {
   .pf-c-page__sidebar {
     background-color: #31475e;
     --pf-c-page__sidebar--Transition: all 100ms ease;
+    overflow-y: hidden;
   }
 }
 
@@ -359,19 +360,9 @@ h6 {
     --pf-c-page__sidebar--BoxShadow: none;
   }
 
-  &::-webkit-scrollbar {
-    width: 7px;
-    background: none;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: #d8dadb;
-    border-radius: 7.5px;
-    opacity: 1;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: none;
+  &-body {
+    padding-bottom: 0 !important;
+    height: 100%;
   }
 
   &.pf-m-expanded {
@@ -409,6 +400,7 @@ h6 {
     }
 
     font-size: 13px;
+    height: 100%;
     .pf-c-nav__item .pf-c-nav__separator .pf-c-nav__simple-list .pf-c-nav__link {
       font-size: 13px;
       // fix bug where nav items retain focus after navigation
@@ -433,6 +425,25 @@ h6 {
     // override list styles, necessary due to setting $pf-global--enable-reset to false
     ul {
       list-style: none;
+    }
+
+    &__list-container {
+      height: calc(100% - 35px);
+      overflow-y: auto;
+      &::-webkit-scrollbar {
+        width: 7px;
+        background: none;
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background: #d8dadb;
+        border-radius: 7.5px;
+        opacity: 1;
+      }
+
+      &::-webkit-scrollbar-track {
+        background: none;
+      }
     }
   }
 

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -445,6 +445,10 @@ h6 {
         background: none;
       }
     }
+
+    .without-footer {
+      height: 100%;
+    }
   }
 
   // fix bug where nav items retain focus after navigation

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -746,3 +746,8 @@ div.navIcon > .pf-c-nav__item.pf-m-current > a:first-of-type {
     margin-bottom: 5px;
   }
 }
+
+.hc-cmp-detail-accrodion {
+  --pf-c-accordion--BoxShadow: none !important;
+  --pf-c-accordion--PaddingTop: 0px !important;
+}


### PR DESCRIPTION
* [refactor] TableProps 로 customSorts도 받을 수 있도록 수정하여 테이블 sorting reducer들 넘길 수 있게 수정
* [refactor] 메뉴설정버튼 고려한 LNB 스타일 수정 (스크롤 범위 수정, 싱글클러스터에선 메뉴설정버튼 제거함)
* [refactor] GNB 메뉴설정 버튼 제거 및 NavFooter 추가
* [bugfix] ClusterTemplateClaim status 정렬되도록 수정
* [refactor] 동적메뉴 생성시 각 메뉴타입별 label text 추출하는 부분 유틸화
* [refactor] 싱글클러스터 탭에서 불리는 콜들은 ingress에서 조회한 multicluster도메인으로 설정되도록 리팩토링
* [feat] ClusterMenuPolicy 리스트페이지, 디테일페이지 menu preview 기능 추가 구현