### PR TITLE
[feat][patch][IMS]273581 롤 폼에디터에 가이드 문구 추가 요청

### DIFF
--- a/frontend/public/components/hypercloud/form/roles/create-role.tsx
+++ b/frontend/public/components/hypercloud/form/roles/create-role.tsx
@@ -96,7 +96,7 @@ const defaultValuesTemplate = {
     {
       verbs: ['*'],
       apiGroups: ['*'],
-      resources: ['*'],
+      resources: [],
     },
   ],
 };
@@ -117,7 +117,7 @@ const roleFormFactory = (params, obj) => {
   const defaultValues = obj || defaultValuesTemplate;
 
   if (!defaultValues.rules) {
-    defaultValues.rules = [{ apiGroups: ['*'], resources: ['*'], verbs: ['*'] }];
+    defaultValues.rules = [{ apiGroups: ['*'], resources: [], verbs: ['*'] }];
   }
   if (defaultValues.rules) {
     defaultValues.rules.forEach((rule, ruleIndex) => {
@@ -254,8 +254,8 @@ const RuleItem = props => {
               </Section>
             )}
             {ruleTypeToggle === 'Resource' ? (
-              <>
-                <Section label={t('SINGLE:MSG_ROLES_CREATEFORM_DIV2_10')} id={`apiGroups[${index}]`} isRequired={true}>
+              <>                
+                <Section label={t('SINGLE:MSG_ROLES_CREATEFORM_DIV2_10')} id={`apiGroups[${index}]`} isRequired={true} help={true} helpTitle='API 그룹' helpText='API 그룹은 리소스 타입으로 구성되어 있습니다. □ 체크시, 선택한 API 그룹의 리소스 목록을 리소스 필드에서 조회합니다.'>
                   <Controller
                     as={<DropdownCheckAddComponent name={`${name}[${index}].apiGroups`} defaultValues={item.apiGroups} methods={methods} useResourceItemsFormatter={false} items={apiGroupList} placeholder={t('SINGLE:MSG_ROLES_CREATEFORM_DIV2_27')} clearAllText={t('SINGLE:MSG_ROLES_CREATEFORM_DIV2_29')} chipsGroupTitle={t('COMMON:MSG_DETAILS_TABDETAILS_RULES_TABLEHEADER_2')} shrinkOnSelectAll={false} showSelectAllOnEmpty={false} menuWidth="300px" buttonWidth="300px" />}
                     control={methods.control}
@@ -451,7 +451,7 @@ const CreateRoleComponent: React.FC<RoleFormProps> = props => {
 
       {loaded ? (
         <Section id="rules" isRequired={true}>
-          <ListView methods={methods} name={`rules`} addButtonText={t('SINGLE:MSG_ROLES_CREATEFORM_DIV2_22')} headerFragment={<></>} itemRenderer={ruleItemRenderer} defaultItem={{ apiGroups: [{ label: 'All', value: '*', checked: false, added: true }], resources: [{ label: 'All', value: '*' }], verbs: ['*'] }} defaultValues={defaultValues.rules} />
+          <ListView methods={methods} name={`rules`} addButtonText={t('SINGLE:MSG_ROLES_CREATEFORM_DIV2_22')} headerFragment={<></>} itemRenderer={ruleItemRenderer} defaultItem={{ apiGroups: [{ label: 'All', value: '*', checked: false, added: true }], resources: [], verbs: ['*'] }} defaultValues={defaultValues.rules} />
         </Section>
       ) : (
         <LoadingInline />

--- a/frontend/public/components/hypercloud/utils/dropdown-check-add.tsx
+++ b/frontend/public/components/hypercloud/utils/dropdown-check-add.tsx
@@ -68,7 +68,7 @@ const ResourceItem = (isResourceItem, shrinkOnSelectAll, selectAllChipObj, showS
         <div>
             <span className={'co-resource-item'} id={DROPDOWN_SECTION_ID} style={{ display: 'block'}} >
                  
-                    <input id={DROPDOWN_SECTION_ID} style={{ marginLeft: '10px', marginRight: '10px' }} type="checkbox" checked={isChecked} disabled={!isAdded}
+                    <input id={DROPDOWN_SECTION_ID} style={{ marginLeft: '10px', marginRight: '10px' }} type="checkbox" checked={isChecked}
                     onClick={() => {
                         if (isExist !== true) {                            
                             data.checked = true;

--- a/frontend/public/components/hypercloud/utils/section.tsx
+++ b/frontend/public/components/hypercloud/utils/section.tsx
@@ -1,6 +1,7 @@
 import * as _ from 'lodash-es';
 import classNames from 'classnames';
 import * as React from 'react';
+import { FieldLevelHelp } from '../../utils';
 
 const Node = ({ className, children, description, valid, validationErrorDesc }) => (
   <div className={className}>
@@ -18,7 +19,7 @@ const CombineNodes = (id, description, children, valid, validationErrorDesc) => 
   return isArray ? children.map((cur, idx) => <Node className={className} key={`${id}-${idx}`} children={cur} description={description} valid={valid} validationErrorDesc={validationErrorDesc} />) : <Node className={className} children={children} description={description} valid={valid} validationErrorDesc={validationErrorDesc} />;
 };
 
-export const Section: React.FC<SectionProps> = ({ id, label, description, children, isRequired = false, valid = true, validationErrorDesc }) => {
+export const Section: React.FC<SectionProps> = ({ id, label, description, children, isRequired = false, valid = true, validationErrorDesc, help = false, helpText, helpTitle }) => {
   let result = CombineNodes(id, description, children, valid, validationErrorDesc);
   return (
     <div className="form-group">
@@ -26,6 +27,14 @@ export const Section: React.FC<SectionProps> = ({ id, label, description, childr
         <label className={'control-label ' + (isRequired ? 'co-required' : '')} htmlFor={id}>
           {label}
         </label>
+      )}
+      {help && (
+        <div style={{display: 'inline-block', marginLeft: 5}}>
+          <FieldLevelHelp>
+            <h2>{helpTitle}</h2>
+            <p>{helpText}</p>
+          </FieldLevelHelp>
+        </div>
       )}
       <div className="row" key={id}>
         {result}
@@ -42,4 +51,7 @@ type SectionProps = {
   isRequired?: boolean;
   valid?: boolean;
   validationErrorDesc?: string;
+  help?: boolean;
+  helpTitle?: string;
+  helpText?: string;
 };


### PR DESCRIPTION
체크박스 액션과 [+] 버튼 액션의 종속성 제거

'API 그룹' 레이블 우측 아이콘 버튼 클릭 시, 가이드 Popover
- section에 help 추가