### PR TITLE
[refactor] 싱글 클러스터 클러스터 리스트 API 호출 부분 조건 수정

### DIFF
--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -31,7 +31,7 @@ const NavHeader_: React.FC<NavHeaderProps & StateProps> = ({ setActivePerspectiv
   const [isClusterExist, setIsClusterExist] = React.useState(false)
 
   React.useEffect(() => {
-    if (isClusterExist===false || isPerspectiveDropdownOpen) {
+    if (isPerspectiveDropdownOpen) {
     coFetchJSON(`${location.origin}/api/multi-hypercloud/clustermanagers/access?userId=${getId()}${getUserGroup()}`, 'GET')
     .then(result => result.items)
     .then(res => {
@@ -95,7 +95,7 @@ const NavHeader_: React.FC<NavHeaderProps & StateProps> = ({ setActivePerspectiv
       
       ));
     },
-    [activePerspective, onPerspectiveSelect],
+    [activePerspective, onPerspectiveSelect,isClusterExist],
   );
 
   const { t } = useTranslation();

--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -76,7 +76,7 @@ const NavHeader_: React.FC<NavHeaderProps & StateProps> = ({ setActivePerspectiv
 
       return perspectives.map((nextPerspective: Perspective) => (
         isClusterExist===false && nextPerspective.properties.id=="SINGLE" ? 
-        <Tooltip position ="top" content ={t('COMMON:MSG_LNB_CONSOLE_1')} >
+        <Tooltip key={nextPerspective.properties.id} position ="top" content ={t('COMMON:MSG_LNB_CONSOLE_1')} >
         <DropdownItem key={nextPerspective.properties.id} onClick={(event: React.MouseEvent<HTMLLinkElement>) => onPerspectiveSelect(event, nextPerspective)} component="button" isDisabled ={true}>
           <Title size="md">
             <span className="oc-nav-header__icon">{nextPerspective.properties.icon}</span>


### PR DESCRIPTION
 싱글 클러스터 클러스터 리스트 API 호출 부분 조건 수정
-> 기존 : 클러스터 존재 X && dropdown open 
-> 변경 : dropdown open 

 싱글 클러스터 클러스터 리스트 API 호출 부분 조건 수정했을 경우 변경된 isClusterExist state 가 UI에 반영 안되는 버그 수정
-> getPerspectiveItems = useCallback 인자로  isClusterExist 추가 해줌