### PR TITLE
[FEAT][patch]싱글 클러스터 개요 주요 리소스 및 클레임 카드 수정

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/cluster-dashboard.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/cluster-dashboard.tsx
@@ -64,7 +64,7 @@ export const ClusterDashboard: React.FC<{}> = () => {
 
   const mainCards = [{ Card: StatusCard }, { Card: UtilizationCard }];
   const leftCards = [{ Card: DetailsCard }];
-  const rightCards = isSingleCluster ? [{ Card: ActivityCard }] : [{ Card: InventoryCard }, { Card: ActivityCard }];
+  const rightCards = [{ Card: InventoryCard }, { Card: ActivityCard }];
 
   const dashboard = <DashboardGrid mainCards={mainCards} leftCards={leftCards} rightCards={rightCards} isSingleCluster={isSingleCluster} />;
   const loading = <div></div>;

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/inventory-card.tsx
@@ -10,6 +10,8 @@ import { AsyncComponent } from '../../../utils';
 import { useExtensions, DashboardsOverviewInventoryItem, isDashboardsOverviewInventoryItem, LazyLoader } from '@console/plugin-sdk';
 import { useK8sWatchResource, useK8sWatchResources, WatchK8sResources } from '../../../utils/k8s-watch-hook';
 import { useTranslation } from 'react-i18next';
+import { getActivePerspective } from '@console/internal/actions/ui';
+import { isSingleClusterPerspective } from '../../../../hypercloud/perspectives';
 // import { find } from 'lodash';
 import { NamespaceClaimModel, ResourceQuotaClaimModel } from '../../../../models/hypercloud';
 import { NodeModel, PersistentVolumeClaimModel, PodModel, ServiceModel } from '../../../../models';
@@ -75,7 +77,12 @@ const RCCard: React.FC<RCCardProps> = React.memo(({ rcItems }) => {
 export const InventoryCard = () => {
   const itemExtensions = useExtensions<DashboardsOverviewInventoryItem>(isDashboardsOverviewInventoryItem);
   const { resourceItems, claimItems } = React.useMemo(() => splitItems(itemExtensions), [itemExtensions]);
+  const [isSingleCluster, setSingleCluster] = React.useState(isSingleClusterPerspective());
   const { t } = useTranslation();
+
+  React.useEffect(() => {
+    setSingleCluster(isSingleClusterPerspective());
+  }, [getActivePerspective()]);
 
   return (
     <DashboardCard data-test-id="inventory-card">
@@ -84,9 +91,9 @@ export const InventoryCard = () => {
       </DashboardCardHeader>
       <DashboardCardBody>
         <RCCard rcItems={resourceItems} />
-        <div className={classNames('co-status-card__alerts-body', 'co-dashboard-card__body--top-margin')}>
+        {isSingleCluster ? null : <div className={classNames('co-status-card__alerts-body', 'co-dashboard-card__body--top-margin')}>
           <RCCard rcItems={claimItems} />
-        </div>
+        </div> }
       </DashboardCardBody>
     </DashboardCard>
   );


### PR DESCRIPTION
기존 싱글 클러스터 홈/개요 화면에서 주요 리소스 및 클레임 카드 삭제되었던 부분 다시 복구
![image](https://user-images.githubusercontent.com/44824463/152295420-7890500e-cb61-44ca-bb18-55fedf8bb074.png)
박스 안에 있는 부분만 안보이도록 수정