### PR TITLE
[bugfix][fatch] 롤 생성 API 그룹 선택 드롭다운 컴포넌트 chip count 버그 수정

### DIFF
--- a/frontend/public/components/hypercloud/utils/dropdown-check-add.tsx
+++ b/frontend/public/components/hypercloud/utils/dropdown-check-add.tsx
@@ -386,10 +386,21 @@ export const DropdownCheckAddComponent = React.forwardRef<HTMLInputElement, Drop
     }
     setInputValue(value);
   };
+  const getChipsCount = ()=>{
+    const isAllSelected = chips.filter(chip=> chip.label.includes('All')).length
+
+    if(selectAllChecked ||isAllSelected){
+      return formattedOptions.length
+    }
+    else{
+      return chips.length
+    }
+  }
   const getOptions = options => [selectAllOption, ...options];
 
   const toggleOpen = () => {
     window.addEventListener('click', onWindowClick);
+   
     setIsOpen(!isOpen);
   };
 
@@ -401,7 +412,7 @@ export const DropdownCheckAddComponent = React.forwardRef<HTMLInputElement, Drop
     if (chip.key === SELECT_ALL_VALUE) {
       setDropdownSettings(false, [], []);
     } else {
-      const newValues = selectedValues?.filter(item => chip.key !== item.label);
+      const newValues = chips?.filter(item => chip.key !== item.label);
       setDropdownSettings(false, newValues, newValues);
     }
   };
@@ -417,11 +428,13 @@ export const DropdownCheckAddComponent = React.forwardRef<HTMLInputElement, Drop
       return;
     }
     hide(event);
+    setInputValue('')
   };
 
   const hide = e => {
     e && e.stopPropagation();
     window.removeEventListener('click', onWindowClick);
+    
     setIsOpen(false);
   };
 
@@ -452,12 +465,12 @@ export const DropdownCheckAddComponent = React.forwardRef<HTMLInputElement, Drop
             deleteChip={onDeleteChip}
             categoryName={chipsGroupTitle}
           >
-            <Dropdown ref={dropdownElement} isOpen={isOpen} onClose={toggleOpen} target={<DropdownMainButton label={placeholder} toggleOpen={toggleOpen} count={selectAllChecked ? formattedOptions.length : selectedValues.length || 0} buttonWidth={buttonWidth} />}>
+            <Dropdown ref={dropdownElement} isOpen={isOpen} onClose={toggleOpen} target={<DropdownMainButton label={placeholder} toggleOpen={toggleOpen} count={ getChipsCount() } buttonWidth={buttonWidth} />}>
               <Select
                 name={name}
                 autoFocus
                 styles={customStyles}
-                //value={selectedValues || []}
+                value={selectedValues || []}
                 options={getOptions(formattedOptions)}
                 controlShouldRenderValue={false}
                 isMulti

--- a/frontend/public/components/hypercloud/utils/dropdown-check-add.tsx
+++ b/frontend/public/components/hypercloud/utils/dropdown-check-add.tsx
@@ -387,9 +387,13 @@ export const DropdownCheckAddComponent = React.forwardRef<HTMLInputElement, Drop
     setInputValue(value);
   };
   const getChipsCount = ()=>{
-    const isAllSelected = chips.filter(chip=> chip.label.includes('All')).length
+    
+    const returnIsAllSelected = ()=>{
+      const isAll = chips.findIndex(chip=>chip.label==="All")
+      return isAll ===-1 ? false : true 
+    }
 
-    if(selectAllChecked ||isAllSelected){
+    if(selectAllChecked ||returnIsAllSelected()){
       return formattedOptions.length
     }
     else{

--- a/frontend/public/components/hypercloud/utils/dropdown-check-add.tsx
+++ b/frontend/public/components/hypercloud/utils/dropdown-check-add.tsx
@@ -386,13 +386,12 @@ export const DropdownCheckAddComponent = React.forwardRef<HTMLInputElement, Drop
     }
     setInputValue(value);
   };
+  const returnIsAllSelected = ()=>{
+    const isAllSelected = chips.findIndex(chip=>chip.label==="All")
+    return isAllSelected ===-1 ? false : true 
+  }
+  
   const getChipsCount = ()=>{
-    
-    const returnIsAllSelected = ()=>{
-      const isAll = chips.findIndex(chip=>chip.label==="All")
-      return isAll ===-1 ? false : true 
-    }
-
     if(selectAllChecked ||returnIsAllSelected()){
       return formattedOptions.length
     }


### PR DESCRIPTION
문제 현상 : 
- 드롭다운 컴포넌트 우측 count 에 선택된 chip 수만 나와야 하는데 resource 수와 합쳐졌음. chip 부분에도 처음에는 선택된 chip만 나오지만 chip을 하나 삭제하면 선택된 resource도 chip으로 나왔음.
- input 창에 텍스트 입력하면 드롭다운 닫혀도 계속 inputValue가 남아있는 문제

해결 : 
- 드롭다운 close 될 때 마다 inputValue빈 텍스트로 초기화 해줌 
- getChipsCount 라는 chip이 모두 선택되었는지 여부에 따라 chip 수를 return 해주는 함수 구현 
