### PR TITLE
[refactor] 클러스터 타입에 대한 label 형식 수정

### DIFF
--- a/frontend/public/components/hypercloud/cluster.tsx
+++ b/frontend/public/components/hypercloud/cluster.tsx
@@ -45,6 +45,8 @@ const getMenuActions = type => {
   return menuActions;
 };
 
+const CLUSTER_TYPE_LABEL = 'clustermanager.cluster.tmax.io/cluster-type';
+
 const ClusterType = {
   CREATED: 'created',
   REGISTERED: 'registered',
@@ -101,7 +103,7 @@ const tableProps: TableProps = {
     },
   ],
   row: (cluster: K8sResourceKind) => {
-    const type = cluster.metadata.labels?.type;
+    const type = cluster.metadata.labels[CLUSTER_TYPE_LABEL] || '';
     return [
       {
         children: <ResourceLink kind={kind} name={cluster.metadata.name} displayName={cluster.metadata.name} title={cluster.metadata.uid} namespace={cluster.metadata.namespace} />,


### PR DESCRIPTION
`labels['type']` 에서 `labels.['clustermanager.cluster.tmax.io/cluster-type']` 으로 형식이 변경됨