### PR TITLE
[feat][patch] NodePort 타입 서비스에 대한 추가 처리 (서버플래그 추가)

### DIFF
--- a/frontend/public/components/hypercloud/utils/menu-utils.ts
+++ b/frontend/public/components/hypercloud/utils/menu-utils.ts
@@ -66,13 +66,17 @@ const initializeMenuUrl = async (labelSelector: any, menuKey: string, port: stri
 
 const initializePort = async () => {
   try {
-    const { spec } = await k8sGet(ServiceModel, 'api-gateway', 'api-gateway-system', { basePath: `${location.origin}/api/console` });
-    const port = spec.type === 'LoadBalancer' ? 443 : spec.ports.find((port: any) => port.name === 'websecure').port;
-    return `:${port}`;
+    // 서비스 타입이 nodeport일 경우 websecure의 port 값 매핑
+    if (window.SERVER_FLAGS.svcType === 'NodePort') {
+      const { spec } = await k8sGet(ServiceModel, 'api-gateway', 'api-gateway-system', { basePath: `${location.origin}/api/console` });
+      if (spec.type === 'NodePort') {
+        return `:${spec.ports.find((port: any) => port.name === 'websecure').port}`;
+      }
+    }
   } catch (error) {
     console.error(`Failed to get api-gateway service:\n${error}`);
-    return '';
   }
+  return '';
 };
 
 export const initializationForMenu = async () => {

--- a/frontend/public/declarations.d.ts
+++ b/frontend/public/declarations.d.ts
@@ -44,6 +44,7 @@ declare interface Window {
     KeycloakRealm: string;
     gitlabURL: string;
     singleClusterBasePath: string;
+    svcType: string;
   };
   windowError?: boolean | string;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;


### PR DESCRIPTION
svcType이 `NodePort`인 경우에만 기존 로직대로 진행, 그렇지 않으면 기본 포트로 매핑