### PR TITLE
[refactor] 싱글 클러스터 k8s 콜 수정

### DIFF
--- a/frontend/public/co-fetch.js
+++ b/frontend/public/co-fetch.js
@@ -161,11 +161,9 @@ export const coFetchCommon = (url, method = 'GET', options = {}, timeout) => {
 
   if (url.indexOf('https://') < 0 && url.indexOf('http://') < 0 && isSingleClusterPerspective()) {
     // MEMO : 도메인 뒷부분만 url로 들어오는 경우, singlecluster perspective면 ingress 도메인 주소로 설정해줘야함.
-
-    // MEMO : 마스터클러스터에선 /api/kubernets/ prefix로 쏘는 콜은 hypercloud-api-server를 타는 콜인데, 싱글클러스터의 경우엔 kube로 직접 콜을 해줘야 함.
-    // MEMO : 콜의 명세는 kube docs나 openshift docs를 참조해서 작업하고 있다고 하셔서(서버담당자분이) 프론트쪽 콜들도 /api/kubernetes/부분 제거한 뒷부분은
-    // MEMO : kube 콜과 형식 동일한 경우가 대부분이라 /api/kubernetes/부분만 없애줌.
-    url = url.replace('api/kubernetes/', '/');
+    if (!url.startsWith('/')) {
+      url = `/${url}`;
+    }
     url = `${getSingleClusterFullBasePath()}${url}`;
   }
   // Pass headers last to let callers to override Accept.

--- a/frontend/public/module/k8s/resource.js
+++ b/frontend/public/module/k8s/resource.js
@@ -9,9 +9,9 @@ import { getId, getUserGroup } from '../../hypercloud/auth';
 import { resourceSchemaBasedMenuMap } from '../../components/hypercloud/form'
 
 
-export const getDynamicProxyPath = (cluster) => {
+const getDynamicProxyPath = cluster => {
   if (isSingleClusterPerspective()) {
-    return getSingleClusterFullBasePath();
+    return `${getSingleClusterFullBasePath()}/api/kubernetes`;
   } else if (cluster) {
     return `${window.SERVER_FLAGS.basePath}api/${cluster}`;
   } else {
@@ -20,8 +20,7 @@ export const getDynamicProxyPath = (cluster) => {
 };
 
 /** @type {(model: K8sKind, cluster?: string, basePath?: string) => string} */
-export const getK8sAPIPath = ({ apiGroup = 'core', apiVersion}, cluster, basePath)
-=> {
+export const getK8sAPIPath = ({ apiGroup = 'core', apiVersion}, cluster, basePath) => {
   const isLegacy = apiGroup === 'core' && apiVersion === 'v1';
 
   let p = basePath || getDynamicProxyPath(cluster);
@@ -41,8 +40,7 @@ export const getK8sAPIPath = ({ apiGroup = 'core', apiVersion}, cluster, basePat
 };
 
 /** @type {(model: K8sKind) => string} */
-const getClusterAPIPath = ({ apiGroup = 'core', apiVersion}, cluster)
-=> {
+const getClusterAPIPath = ({ apiGroup = 'core', apiVersion}, cluster) => {
   const isLegacy = apiGroup === 'core' && apiVersion === 'v1';
   let p = multiClusterBasePath;
 
@@ -139,7 +137,7 @@ const resourceNamespaceURL = (model) => {
   if (isSingleClusterPerspective()) {
     // MEMO : 싱글클러스터의 경우 네임스페이스 조회콜은 kubernetes 콜로 보냄
     const plural = isNamespace(model) ? 'namespaces' : 'namespaceclaims';
-    return `${getSingleClusterFullBasePath()}/api/v1/${plural}`;
+    return `${getSingleClusterFullBasePath()}/api/kubernetes/api/v1/${plural}`;
   } else {
     const path = isNamespace(model) ? 'namespace' : 'namespaceClaim';
     return `${document.location.origin}/api/hypercloud/${path}?userId=${getId()}${getUserGroup()}`;


### PR DESCRIPTION
싱글 클러스터에서 k8s 리소스 조회 콜을 `/{ns}/{cluster}/{k8s_api_url}` 에서 `/{ns}/{cluster}/api/kubernetes/{k8s_api_url}` 으로 변경