### PR TITLE
[refactor] 네임스페이스 삭제 모달 Functional Component 및 TSX 파일로 리팩토링

### DIFF
--- a/frontend/public/components/modals/delete-namespace-modal.jsx
+++ b/frontend/public/components/modals/delete-namespace-modal.jsx
@@ -1,61 +1,44 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
-
-import { ResourceLabel } from '@console/internal/models/hypercloud/resource-plural';
 import { k8sKill } from '../../module/k8s';
 import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
-import { history, PromiseComponent } from '../utils';
+import { history } from '../utils';
 import { YellowExclamationTriangleIcon } from '@console/shared';
-import { withTranslation, Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
+import { withHandlePromise } from '../utils';
 
-const DeleteNamespaceModal = withTranslation()(
-  class DeleteNamespaceModal extends PromiseComponent {
-    constructor(props) {
-      super(props);
-      this.state = Object.assign(this.state, { isTypedNsMatching: false });
-      this._submit = this._submit.bind(this);
-      this._close = props.close.bind(this);
-      this._cancel = props.cancel.bind(this);
-      this._matchTypedNamespace = this._matchTypedNamespace.bind(this);
-    }
+export const DeleteNamespaceModal = withHandlePromise(({ cancel, close, kind, resource, handlePromise, errorMessage, inProgress }) => {
+  const { t } = useTranslation();
+  const [confirmed, setConfirmed] = React.useState(false);
 
-    _matchTypedNamespace(e) {
-      this.setState({ isTypedNsMatching: e.target.value === this.props.resource.metadata.name });
-    }
+  const onSubmit = event => {
+    event.preventDefault();
+    handlePromise(k8sKill(kind, resource)).then(() => {
+      close?.();
+      history.push(`/k8s/cluster/${kind.plural}`);
+    });
+  };
 
-    _submit(event) {
-      event.preventDefault();
-      this.handlePromise(k8sKill(this.props.kind, this.props.resource)).then(() => {
-        this._close();
-        history.push(`/k8s/cluster/${this.props.kind.plural}`);
-      });
-    }
+  const onKeyUp = e => {
+    setConfirmed(e.currentTarget.value === resource.metadata.name);
+  };
 
-    render() {
-      const { t } = this.props;
-      const NamespaceName = () => <strong className="co-break-word">{this.props.resource.metadata.name}</strong>;
-      return (
-        <form onSubmit={this._submit} name="form" className="modal-content ">
-          <ModalTitle className="modal-header">
-            <YellowExclamationTriangleIcon className="co-icon-space-r" />
-            {t('COMMON:MSG_MAIN_POPUP_17')}
-          </ModalTitle>
-          <ModalBody>
-            <p style={{ whiteSpace: 'pre-wrap' }}>
-              <Trans i18nKey="COMMON:MSG_MAIN_POPUP_18">{[<NamespaceName />]}</Trans>
-            </p>
-            <input type="text" className="pf-c-form-control" onKeyUp={this._matchTypedNamespace} placeholder={t('COMMON:MSG_MAIN_POPUP_19')} autoFocus={true} />
-          </ModalBody>
-          <ModalSubmitFooter submitText={t('COMMON:MSG_MAIN_POPUP_COMMIT_2')} submitDisabled={!this.state.isTypedNsMatching} cancel={this._cancel} errorMessage={this.state.errorMessage} inProgress={this.state.inProgress} submitDanger />
-        </form>
-      );
-    }
-  },
-);
+  const NamespaceName = () => <strong className="co-break-word">{resource.metadata.name}</strong>;
 
-DeleteNamespaceModal.propTypes = {
-  kind: PropTypes.object,
-  resource: PropTypes.object,
-};
+  return (
+    <form onSubmit={onSubmit} name="form" className="modal-content ">
+      <ModalTitle className="modal-header">
+        <YellowExclamationTriangleIcon className="co-icon-space-r" />
+        {t('COMMON:MSG_MAIN_POPUP_17')}
+      </ModalTitle>
+      <ModalBody>
+        <p style={{ whiteSpace: 'pre-wrap' }}>
+          <Trans i18nKey="COMMON:MSG_MAIN_POPUP_18">{[<NamespaceName />]}</Trans>
+        </p>
+        <input type="text" className="pf-c-form-control" onKeyUp={onKeyUp} placeholder={t('COMMON:MSG_MAIN_POPUP_19')} autoFocus={true} />
+      </ModalBody>
+      <ModalSubmitFooter submitText={t('COMMON:MSG_MAIN_POPUP_COMMIT_2')} submitDisabled={!confirmed} cancel={() => cancel?.()} errorMessage={errorMessage} inProgress={inProgress} submitDanger />
+    </form>
+  );
+});
 
 export const deleteNamespaceModal = createModalLauncher(DeleteNamespaceModal);

--- a/frontend/public/components/modals/delete-namespace-modal.tsx
+++ b/frontend/public/components/modals/delete-namespace-modal.tsx
@@ -1,21 +1,26 @@
 import * as React from 'react';
-import { k8sKill } from '../../module/k8s';
-import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
-import { history } from '../utils';
+import { k8sKill, K8sKind, K8sResourceKind } from '../../module/k8s';
+import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter, ModalComponentProps } from '../factory/modal';
+import { HandlePromiseProps, history } from '../utils';
 import { YellowExclamationTriangleIcon } from '@console/shared';
 import { Trans, useTranslation } from 'react-i18next';
 import { withHandlePromise } from '../utils';
 
-export const DeleteNamespaceModal = withHandlePromise(({ cancel, close, kind, resource, handlePromise, errorMessage, inProgress }) => {
+export const DeleteNamespaceModal = withHandlePromise((props: DeleteNamespaceModalProps) => {
+  const { cancel, close, kind, resource, handlePromise, errorMessage, inProgress } = props;
   const { t } = useTranslation();
   const [confirmed, setConfirmed] = React.useState(false);
 
   const onSubmit = event => {
     event.preventDefault();
-    handlePromise(k8sKill(kind, resource)).then(() => {
-      close?.();
-      history.push(`/k8s/cluster/${kind.plural}`);
-    });
+    handlePromise(k8sKill(kind, resource))
+      .then(() => {
+        close?.();
+        history.push(`/k8s/cluster/${kind.plural}`);
+      })
+      .catch(() => {
+        /* do nothing */
+      });
   };
 
   const onKeyUp = e => {
@@ -42,3 +47,9 @@ export const DeleteNamespaceModal = withHandlePromise(({ cancel, close, kind, re
 });
 
 export const deleteNamespaceModal = createModalLauncher(DeleteNamespaceModal);
+
+type DeleteNamespaceModalProps = {
+  resource: K8sResourceKind;
+  kind: K8sKind;
+} & ModalComponentProps &
+  HandlePromiseProps;

--- a/frontend/public/components/modals/delete-namespace-modal.tsx
+++ b/frontend/public/components/modals/delete-namespace-modal.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import { k8sKill, K8sKind, K8sResourceKind } from '../../module/k8s';
 import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter, ModalComponentProps } from '../factory/modal';
 import { HandlePromiseProps, history } from '../utils';
-import { YellowExclamationTriangleIcon } from '@console/shared';
+import { ALL_NAMESPACES_KEY, YellowExclamationTriangleIcon } from '@console/shared';
 import { Trans, useTranslation } from 'react-i18next';
 import { withHandlePromise } from '../utils';
+import { getActiveNamespace, setActiveNamespace } from '@console/internal/actions/ui';
 
 export const DeleteNamespaceModal = withHandlePromise((props: DeleteNamespaceModalProps) => {
   const { cancel, close, kind, resource, handlePromise, errorMessage, inProgress } = props;
@@ -15,6 +16,9 @@ export const DeleteNamespaceModal = withHandlePromise((props: DeleteNamespaceMod
     event.preventDefault();
     handlePromise(k8sKill(kind, resource))
       .then(() => {
+        if (resource.metadata.name === getActiveNamespace()) {
+          setActiveNamespace(ALL_NAMESPACES_KEY);
+        }
         close?.();
         history.push(`/k8s/cluster/${kind.plural}`);
       })


### PR DESCRIPTION
- Class Component → Functional Component 로 변경
- jsx → tsx 로 변경
- 네임스페이스 삭제 이후 네임스페이스 드롭다운이 "모든 네임스페이스"로 변경되도록 수정
- 기존에 `resource-dropdown` 파일에 임시 수정했던 부분 제거