### PR TITLE
[bugfix][patch] 이벤트 화면에서 리소스 chip 모두 삭제 시 All 리소스가 선택되지 않는 현상 수정

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -135,7 +135,7 @@ class _EventsList extends React.Component {
     } else {
       const updateItems = new Set(this.state.selected);
       updateItems.has(selection) ? updateItems.delete(selection) : updateItems.add(selection);
-      this.setState({ selected: updateItems });
+      updateItems.size === 0 ? this.clearSelection() : this.setState({ selected: updateItems });
     }
   };
 


### PR DESCRIPTION
문제 현상 예시: 
![event-old](https://user-images.githubusercontent.com/29051383/166419424-a954d7ff-5e36-423e-a54d-378bbe850c41.gif)

