### PR TITLE
[bugfix] ListPageWrapper_ type 수정

### DIFF
--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -39,7 +39,7 @@ export const TextFilter = props => {
 TextFilter.displayName = 'TextFilter';
 
 // TODO (jon) make this into "withListPageFilters" HOC
-/** @type {React.SFC<{ListComponent?: React.ComponentType<any>, kinds: string[], filters?:any, flatten?: any, data?: any[], rowFilters?: any[], hideToolbar?: boolean, hideLabelFilter?: boolean, tableProps?: any, items?: any[], isK8SResource?: boolean }>} */
+/** @type {React.SFC<{ListComponent?: React.ComponentType<any>, kinds: string[], filters?:any, flatten?: function, data?: any[], rowFilters?: any[], hideToolbar?: boolean, hideLabelFilter?: boolean, tableProps?: any, items?: any[], isK8SResource?: boolean }>} */
 export const ListPageWrapper_ = props => {
   const { flatten, ListComponent, reduxIDs, rowFilters, textFilter, hideToolbar, hideLabelFilter, tableProps, items, isK8SResource = true } = props;
   const data = flatten ? flatten(props.resources) : [];

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -39,7 +39,7 @@ export const TextFilter = props => {
 TextFilter.displayName = 'TextFilter';
 
 // TODO (jon) make this into "withListPageFilters" HOC
-/** @augments {React.PureComponent<{ListComponent?: React.ComponentType<any>, kinds: string[], filters?:any, flatten?: function, data?: any[], rowFilters?: any[], hideToolbar?: boolean, hideLabelFilter?: boolean, tableProps?: any, items?: any[], isK8SResource?: boolean }>} */
+/** @type {React.SFC<{ListComponent?: React.ComponentType<any>, kinds: string[], filters?:any, flatten?: any, data?: any[], rowFilters?: any[], hideToolbar?: boolean, hideLabelFilter?: boolean, tableProps?: any, items?: any[], isK8SResource?: boolean }>} */
 export const ListPageWrapper_ = props => {
   const { flatten, ListComponent, reduxIDs, rowFilters, textFilter, hideToolbar, hideLabelFilter, tableProps, items, isK8SResource = true } = props;
   const data = flatten ? flatten(props.resources) : [];


### PR DESCRIPTION
PipelineAugmentRunsWrapper, list-page.spec.tsx 에서 ListPageWrapper_  사용중이었는데 

수정 이후 타입이 맞지 않는 에러가 발생하고 있어서 수정함