### PR TITLE
Helm bugfix

### DIFF
--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -18,7 +18,7 @@ import { coFetch, coFetchJSON } from '../../co-fetch';
 import { useTranslation, withTranslation } from 'react-i18next';
 import * as noResourceImg from '../../imgs/hypercloud/img_no_resource.svg';
 import { Link } from 'react-router-dom';
-import { ingressUrlWithLabelSelector } from '@console/internal/components/hypercloud/utils/ingress-utils';
+import { CustomMenusMap } from '@console/internal/hypercloud/menu/menu-types';
 
 export const CatalogPageType = {
   SERVICE_INSTANCE: 'ServiceInstance',
@@ -407,21 +407,7 @@ export const Catalog = connectToFlags<CatalogProps>(
 
   React.useEffect(() => {
     const fetchHelmChart = async () => {
-      let serverURL = '';
-      await coFetchJSON(
-        ingressUrlWithLabelSelector({
-          'ingress.tmaxcloud.org/name': 'helm-apiserver',
-        }),
-      ).then(res => {
-        const { items } = res;
-        if (items?.length > 0) {
-          const ingress = items[0];
-          const host = ingress.spec?.rules?.[0]?.host;
-          if (!!host) {
-            serverURL = `https://${host}/helm/charts`;
-          }
-        }
-      });
+      const serverURL = (CustomMenusMap as any).Helm.url + '/helm/charts';
       await coFetch(serverURL).then(async res => {
         const yaml = await res.text();
         const json = safeLoad(yaml);

--- a/frontend/public/components/hypercloud/helmchart.tsx
+++ b/frontend/public/components/hypercloud/helmchart.tsx
@@ -35,7 +35,7 @@ export const HelmchartPage = () => {
     };
     fetchHelmChart();
   }, []);
-  return <>{loading && <ListPage title={t('COMMON:MSG_LNB_MENU_223')} createButtonText={t('COMMON:MSG_MAIN_CREATEBUTTON_1', { 0: t('COMMON:MSG_LNB_MENU_203') })} canCreate={true} items={entries} kind="helmrcharts" createProps={{ to: '/helmcharts/~new', items: [] }} tableProps={tableProps} isK8SResource={false} isClusterScope={true} />}</>;
+  return <>{loading && <ListPage title={t('COMMON:MSG_LNB_MENU_223')} createButtonText={t('COMMON:MSG_MAIN_CREATEBUTTON_1', { 0: t('SINGLE:MSG_HELMCHARTS_HELMCHARTDETAILS_TABDETAILS_1') })} canCreate={true} items={entries} kind="helmrcharts" createProps={{ to: '/helmcharts/~new', items: [] }} tableProps={tableProps} isK8SResource={false} isClusterScope={true} />}</>;
 };
 
 const tableProps: TableProps = {
@@ -236,7 +236,7 @@ export const ChartDetailsTapPage: React.FC<ChartDetailsTapPageProps> = props => 
                 <dt>{t('MULTI:MSG_DEVELOPER_ADD_CREATEFORM_SIDEPANEL_4')}</dt>
                 <dd>
                   <div>
-                    {entry.sources.map(source => {
+                    {entry.sources?.map(source => {
                       return <p key={`source-${source}`}>{source}</p>;
                     })}
                   </div>
@@ -250,7 +250,7 @@ export const ChartDetailsTapPage: React.FC<ChartDetailsTapPageProps> = props => 
             </dd>
             <dt>{t('SINGLE:MSG_HELMCHARTS_HELMCHARTDETAILS_TABDETAILS_6')}</dt>
             <dd>
-              {entry.maintainers.map(m => {
+              {entry.maintainers?.map(m => {
                 return <div key={'mainatainer-key-' + m.name}>{m.name}</div>;
               })}
             </dd>
@@ -324,9 +324,9 @@ const allPages = [
     href: '',
     component: ChartDetailsTapPage,
   },
-  {
-    name: 'COMMON:MSG_DETAILS_TAB_18',
-    href: 'edit',
-    component: HelmchartEditPage,
-  },
+  // {
+  //   name: 'COMMON:MSG_DETAILS_TAB_18',
+  //   href: 'edit',
+  //   component: HelmchartEditPage,
+  // },
 ];

--- a/frontend/public/components/hypercloud/helmrelease.tsx
+++ b/frontend/public/components/hypercloud/helmrelease.tsx
@@ -457,6 +457,7 @@ export const HelmreleasesForm: React.FC<HelmreleasesFormProps> = props => {
                 onChange={updateChartName}
                 buttonClassName="dropdown-btn" // 선택된 아이템 보여주는 button (title) 부분 className
                 itemClassName="dropdown-item" // 드롭다운 아이템 리스트 전체의 className - 각 row를 의미하는 것은 아님
+                disabled={defaultValue}
               />
             </Section>
             {selectChartName && (

--- a/frontend/public/hypercloud/menu/hc-default-menus.ts
+++ b/frontend/public/hypercloud/menu/hc-default-menus.ts
@@ -56,7 +56,7 @@ const DeveloperNavMenus = [
   {
     menuType: MenuType.CONTAINER,
     label: MenuContainerLabels.helm,
-    innerMenus: [CustomMenusMap.HelmChart.kind, CustomMenusMap.HelmRelease.kind],
+    innerMenus: [CustomMenusMap.HelmChart.kind, CustomMenusMap.HelmReleases.kind],
   },
   {
     menuType: MenuType.CONTAINER,

--- a/frontend/public/hypercloud/menu/menu-types.tsx
+++ b/frontend/public/hypercloud/menu/menu-types.tsx
@@ -247,8 +247,8 @@ export const CustomMenusMap: CustomMenus = {
     href: '/helmcharts',
     isMultiOnly: false,
   },
-  HelmRelease: {
-    kind: 'HelmRelease',
+  HelmReleases: {
+    kind: 'HelmReleases',
     visible: true,
     type: MenuLinkType.HrefLink,
     defaultLabel: 'COMMON:MSG_LNB_MENU_204',


### PR DESCRIPTION
헬름 버그 수정

헬름 차트 리스트 페이지
 - 헬름 릴리즈 생성 문구 i18n key 잘못 작성, 헬름 레포지터리 생성으로 교체
  (차트 페이지지만 추가하는건 레포지터리이므로, 추가 기획에서 명확히 될듯합니다.)

헬름 차트 상세 페이지
- 메인테이너스 값이 없는 경우 예외 처리 없음, entry.maintainers.map(()=>{...}) 를 다음과 같이 변경 entry.maintainers?.map(()=>{...}) 
- 헬름 차트는 수정 불가하므로 수정페이지 링크 주석처리

헬름 릴리스 수정 페이지
 - 차트 변경 불가하다고 하였으므로, 이미 값이 있었으면 dropdown disabled

링크 문제
CustomMenusMap  에서 HelmRelease 로 사용하면 기본 리소스 페이지로 이동하는 문제 발견
HelmReleases 로 다시 변경

추가 수정 사항
add page 에서 helm api 호출 시 CustomMenusMap 사용
