### PR TITLE
[bugfix][patch][IMS]278099 [신한은행 The NEXT] Task - step 의 env 값 정보가 UI에 표시되지 않음

### DIFF
--- a/frontend/public/components/hypercloud/form/utils/useInitData.tsx
+++ b/frontend/public/components/hypercloud/form/utils/useInitData.tsx
@@ -102,7 +102,7 @@ const setStepField = (defaultValues, setStep) => {
             envValue = _.get(cur, 'valueFrom.secretKeyRef.name');
             resourceKey = _.get(cur, 'valueFrom.secretKeyRef.key');
             envType = 'secret';
-          } else if (_.has(cur, ['valueFrom', 'configMapKeyRef '])) {
+          } else if (_.has(cur, ['valueFrom', 'configMapKeyRef'])) {
             envValue = _.get(cur, 'valueFrom.configMapKeyRef.name');
             resourceKey = _.get(cur, 'valueFrom.configMapKeyRef.key');
             envType = 'configMap';


### PR DESCRIPTION
configMapKeyRef 뒤의 공백으로 configMapKeyRef 없는것으로 판정하여 task step modal 에서 정상적으로 값을 읽지 못하였음

공백 삭제함