### PR TITLE
[bugfix][patch] 리소스 생성/수정 페이지의 참고 alert 창에 여백 제거

### DIFF
--- a/frontend/public/components/utils/_alerts.scss
+++ b/frontend/public/components/utils/_alerts.scss
@@ -1,7 +1,5 @@
 .co-alert {
   margin-bottom: var(--pf-global--spacer--lg);
-  margin-left: var(--pf-global--spacer--3xl);
-  margin-right: var(--pf-global--spacer--3xl);
   text-align: left;
   // overrides Bootstrap-related line-height issue that causes the title and icon to go out of alignment
   h4 {
@@ -18,4 +16,9 @@
   @media (min-height: $screen-sm-min) {
     max-height: 200px;
   }
+}
+
+.co-alert-space {
+  margin-left: var(--pf-global--spacer--3xl);
+  margin-right: var(--pf-global--spacer--3xl);
 }

--- a/frontend/public/components/utils/status-box.tsx
+++ b/frontend/public/components/utils/status-box.tsx
@@ -74,7 +74,7 @@ export const AccessDenied: React.FC<AccessDeniedProps> = ({ message }) => {
         <MsgBox title={t('COMMON:MSG_COMMON_ERROR_MESSAGE_24')} detail={t('COMMON:MSG_COMMON_ERROR_MESSAGE_27')} />
       </Box>
       {_.isString(message) && (
-        <Alert isInline className="co-alert" variant="danger" title={t('COMMON:MSG_MAIN_POPOVER_1')}>
+        <Alert isInline className="co-alert co-alert-space" variant="danger" title={t('COMMON:MSG_MAIN_POPOVER_1')}>
           {message}
         </Alert>
       )}


### PR DESCRIPTION
이전에 접근 제한 에러 페이지 UI를 수정하면서 생긴 side-effect 수정

![Untitled](https://user-images.githubusercontent.com/29051383/181672179-25cff42d-491e-4aa0-a37d-fe6116bc9007.png)
