### PR TITLE
[feat][patch] 챗봇 리소스 상태 보기 버튼에 대한 라우팅 기능 구현

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -145,14 +145,21 @@ type NodesTableProps = React.ComponentProps<typeof Table> & {
   data: NodeKind[];
 };
 
+export const NODE_STATUS_QUERY_PARAM = 'node-status';
+
+export enum NODE_STATUS {
+  READY = 'Ready',
+  NOTREADY = 'Not Ready',
+}
+
 const filters = [
   {
     filterGroupName: 'Status',
-    type: 'node-status',
+    type: NODE_STATUS_QUERY_PARAM,
     reducer: nodeStatus,
     items: [
-      { id: 'Ready', title: 'Ready' },
-      { id: 'Not Ready', title: 'Not Ready' },
+      { id: NODE_STATUS.READY, title: NODE_STATUS.READY },
+      { id: NODE_STATUS.NOTREADY, title: NODE_STATUS.NOTREADY },
     ],
   },
   {

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -233,7 +233,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = props
     if (location.search.indexOf('rowFilter-pod-status') >= 0) {
       defaultRowFilterSetting(location.search.split('rowFilter-pod-status=')[1].split('%2C'));
     }
-  }, []);
+  }, [location.search]);
 
   React.useEffect(() => {
     if (_.isEmpty(selectedRowFilters) && storeSelectedRows.size > 0) {

--- a/frontend/public/components/hypercloud/chatbot/action.ts
+++ b/frontend/public/components/hypercloud/chatbot/action.ts
@@ -89,6 +89,7 @@ class RouteActionHandler implements ActionHandler {
     const namespaced = allModels().find(model => model.plural === data.resource)?.namespaced;
     let _path = `/k8s/${data?.namespace ? `ns/${data.namespace}` : namespaced ? 'all-namespaces' : 'cluster'}/${data.resource}`;
 
+    // make a search query
     if (data.status) {
       const status = getResourceStatus(data?.resource);
       if (status) {

--- a/frontend/public/components/hypercloud/chatbot/action.ts
+++ b/frontend/public/components/hypercloud/chatbot/action.ts
@@ -1,4 +1,6 @@
 import { history } from '@console/internal/components/utils';
+import { allModels } from '@console/internal/module/k8s/k8s-models';
+import { getResourceStatus } from './status';
 import { Config, Message, MessageName, PayloadType, QuickReplyPayload } from './types';
 
 export class ActionFactory {
@@ -79,14 +81,25 @@ class RouteActionHandler implements ActionHandler {
   }
 
   setupRoute(): void {
-    switch (this.payload?.payload) {
-      case 'PENDINGPVCVIEW':
-        // 임시 URL. JSON payload 값에 대해 서버담당자와 논의 필요
-        this.path = '/k8s/all-namespaces/persistentvolumeclaims?rowFilter-pvc-status=Pending';
-        break;
-      default:
-        break;
+    const data = this.payload?.statusView;
+    if (!data) {
+      return;
     }
+
+    const namespaced = allModels().find(model => model.plural === data.resource)?.namespaced;
+    let _path = `/k8s/${data?.namespace ? `ns/${data.namespace}` : namespaced ? 'all-namespaces' : 'cluster'}/${data.resource}`;
+
+    if (data.status) {
+      const status = getResourceStatus(data?.resource);
+      if (status) {
+        let query = '';
+        let params = status[data.status].join(',');
+        query = `rowFilter-${status.queryParam}=` + encodeURIComponent(params);
+        _path = [_path, query].join('?');
+      }
+    }
+
+    this.path = _path;
   }
 
   execute(): void {

--- a/frontend/public/components/hypercloud/chatbot/status.ts
+++ b/frontend/public/components/hypercloud/chatbot/status.ts
@@ -1,0 +1,44 @@
+import { NODE_STATUS, NODE_STATUS_QUERY_PARAM } from '@console/app/src/components/nodes/NodesPage';
+import { PERSISTENTVOLUMECLAIM_STATUS, PERSISTENTVOLUMECLAIM_STATUS_QUERY_PARAM } from '@console/internal/components/persistent-volume-claim';
+import { POD_STATUS, POD_STATUS_QUERY_PARAM } from '@console/internal/components/pod';
+
+interface StatusQuery {
+  queryParam: string;
+}
+
+interface StatusDetails {
+  [key: string]: string[];
+}
+
+export type ResourceStatus = StatusQuery | StatusDetails;
+
+const nodeStatus: ResourceStatus = {
+  queryParam: NODE_STATUS_QUERY_PARAM,
+  ready: [NODE_STATUS.READY],
+  notready: [NODE_STATUS.NOTREADY],
+};
+
+const persistentVolumeClaimStatus: ResourceStatus = {
+  queryParam: PERSISTENTVOLUMECLAIM_STATUS_QUERY_PARAM,
+  bound: [PERSISTENTVOLUMECLAIM_STATUS.BOUND],
+  notbound: [PERSISTENTVOLUMECLAIM_STATUS.LOST, PERSISTENTVOLUMECLAIM_STATUS.PENDING, PERSISTENTVOLUMECLAIM_STATUS.TERMINATING],
+};
+
+const podStatus: ResourceStatus = {
+  queryParam: POD_STATUS_QUERY_PARAM,
+  normal: [POD_STATUS.SUCCEEDED, POD_STATUS.RUNNING],
+  abnormal: [POD_STATUS.CRASHLOOPBACKOFF, POD_STATUS.FAILED, POD_STATUS.PENDING, POD_STATUS.TERMINATING, POD_STATUS.UNKNOWN],
+};
+
+export const getResourceStatus = (plural: string) => {
+  switch (plural) {
+    case 'nodes':
+      return nodeStatus;
+    case 'persistentvolumeclaims':
+      return persistentVolumeClaimStatus;
+    case 'pods':
+      return podStatus;
+    default:
+      return null;
+  }
+};

--- a/frontend/public/components/hypercloud/chatbot/types.ts
+++ b/frontend/public/components/hypercloud/chatbot/types.ts
@@ -38,9 +38,16 @@ export interface TextPayload extends Payload {
 export interface QuickReplyPayload extends Payload {
   text?: string;
   payload?: any;
+  statusView?: ResourceStatus;
 }
 
 export type MessagePayload = TextPayload | QuickReplyPayload;
+
+export interface ResourceStatus {
+  resource: string;
+  namespace: string;
+  status: string;
+}
 
 interface Overrides {
   [componentToOverride: string]: [

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -165,21 +165,26 @@ const Details_ = ({ flags, obj: pvc }) => {
 
 const Details = connectToFlags(FLAGS.CAN_LIST_PV)(Details_);
 
-const allPhases = ['Pending', 'Bound', 'Lost', 'Terminating'];
+export const PERSISTENTVOLUMECLAIM_STATUS_QUERY_PARAM = 'pvc-status';
+
+export const PERSISTENTVOLUMECLAIM_STATUS = { PENDING: 'Pending', BOUND: 'Bound', LOST: 'Lost', TERMINATING: 'Terminating' };
+
 const filters = t => [
   {
     filterGroupName: t('COMMON:MSG_COMMON_FILTER_10'),
-    type: 'pvc-status',
+    type: PERSISTENTVOLUMECLAIM_STATUS_QUERY_PARAM,
     reducer: pvc => {
       if (pvc?.metadata?.deletionTimestamp) {
         return 'Terminating';
       }
       return pvc.status.phase;
     },
-    items: _.map(allPhases, phase => ({
-      id: phase,
-      title: phase,
-    })),
+    items: [
+      { id: PERSISTENTVOLUMECLAIM_STATUS.PENDING, title: PERSISTENTVOLUMECLAIM_STATUS.PENDING },
+      { id: PERSISTENTVOLUMECLAIM_STATUS.BOUND, title: PERSISTENTVOLUMECLAIM_STATUS.BOUND },
+      { id: PERSISTENTVOLUMECLAIM_STATUS.LOST, title: PERSISTENTVOLUMECLAIM_STATUS.LOST },
+      { id: PERSISTENTVOLUMECLAIM_STATUS.TERMINATING, title: PERSISTENTVOLUMECLAIM_STATUS.TERMINATING },
+    ],
   },
 ];
 

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -432,18 +432,18 @@ export const PodsPage = connect<{}, PodPagePropsFromDispatch, PodPageProps>(
       rowFilters={[
         {
           filterGroupName: t('COMMON:MSG_COMMON_BUTTON_FILTER_3'),
-          type: 'pod-status',
+          type: POD_STATUS_QUERY_PARAM,
           reducer: podPhaseFilterReducer,
           items: [
-            { id: 'Running', title: 'Running' },
-            { id: 'Pending', title: 'Pending' },
-            { id: 'Terminating', title: 'Terminating' },
-            { id: 'CrashLoopBackOff', title: 'CrashLoopBackOff' },
+            { id: POD_STATUS.RUNNING, title: POD_STATUS.RUNNING },
+            { id: POD_STATUS.PENDING, title: POD_STATUS.PENDING },
+            { id: POD_STATUS.TERMINATING, title: POD_STATUS.TERMINATING },
+            { id: POD_STATUS.CRASHLOOPBACKOFF, title: POD_STATUS.CRASHLOOPBACKOFF },
             // Use title "Completed" to match what appears in the status column for the pod.
             // The pod phase is "Succeeded," but the container state is "Completed."
-            { id: 'Succeeded', title: 'Succeeded' },
-            { id: 'Failed', title: 'Failed' },
-            { id: 'Unknown', title: 'Unknown' },
+            { id: POD_STATUS.SUCCEEDED, title: POD_STATUS.SUCCEEDED },
+            { id: POD_STATUS.FAILED, title: POD_STATUS.FAILED },
+            { id: POD_STATUS.UNKNOWN, title: POD_STATUS.UNKNOWN },
           ],
         },
       ]}
@@ -452,6 +452,18 @@ export const PodsPage = connect<{}, PodPagePropsFromDispatch, PodPageProps>(
     />
   );
 });
+
+export const POD_STATUS_QUERY_PARAM = 'pod-status';
+
+export enum POD_STATUS {
+  PENDING = 'Pending',
+  RUNNING = 'Running',
+  SUCCEEDED = 'Succeeded',
+  CRASHLOOPBACKOFF = 'CrashLoopBackOff',
+  FAILED = 'Failed',
+  TERMINATING = 'Terminating',
+  UNKNOWN = 'Unknown',
+}
 
 type ContainerLinkProps = {
   pod: PodKind;


### PR DESCRIPTION
리소스(node, pod, pvc) 에 대한 `네임스페이스` 및 `상태`에 대한 상세 라우팅 기능 추가  

챗봇 데이터에 따른 실제 리소스 상태 분류
1. node: `ready`(ready), `not ready`(not ready)
2. pod: `normal`(running, succeeded), `abnormal`(failed, pending, terminating, crashloopbackoff, unknown) 
3. pvc: `bound`(bound), `not bound`(lost, pending, terminating)
