### PR TITLE
[refact] create-helmrelease  수정시 post 를 put method 로 변경

### DIFF
--- a/frontend/public/components/hypercloud/form/create-form.tsx
+++ b/frontend/public/components/hypercloud/form/create-form.tsx
@@ -73,15 +73,25 @@ export const WithCommonForm = (SubForm, params, defaultValues, NonK8sKindModel?:
           setProgress(true);
           const { postUrl } = inDo;
           const payload = _.omit(inDo, ['nonK8sResource', 'kind', 'postUrl']);
-          coFetchJSON
-            .post(postUrl, payload)
-            .then(() => {
-              history.goBack();
-            })
-            .catch(e => {
-              setProgress(false);
-              setError(`error : ${e.json.error}\ndescription : ${e.json.description}`);
-            });
+          isCreatePage(defaultValues, !!NonK8sKindModel)
+            ? coFetchJSON
+                .post(postUrl, payload)
+                .then(() => {
+                  history.goBack();
+                })
+                .catch(e => {
+                  setProgress(false);
+                  setError(`error : ${e.json.error}\ndescription : ${e.json.description}`);
+                })
+            : coFetchJSON
+                .put(postUrl, payload)
+                .then(() => {
+                  history.goBack();
+                })
+                .catch(e => {
+                  setProgress(false);
+                  setError(`error : ${e.json.error}\ndescription : ${e.json.description}`);
+                });
         } else {
           const model = inDo.kind && inDo.kind !== kind ? modelFor(inDo.kind) : kind && modelFor(kind);
           setProgress(true);

--- a/frontend/public/components/hypercloud/form/helmreleases/create-helmrelease.tsx
+++ b/frontend/public/components/hypercloud/form/helmreleases/create-helmrelease.tsx
@@ -52,7 +52,7 @@ const CreateHelmReleaseComponent: React.FC<HelmReleaseFormProps> = props => {
   const defaultChartName = queryChartName ? queryChartName : defaultValues ? defaultValues.chart.metadata.name : '';
   const defaultReleaseName = defaultValues ? defaultValues.name : '';
   const defaultVersion = defaultValues ? defaultValues.chart.metadata.version : '';
-  const defaultYamlValues = defaultValues ? defaultValues.chart.values : null;
+  const defaultYamlValues = defaultValues ? defaultValues.config : null;
   const defaultRepoName = queryChartRepo ? queryChartRepo : '';
 
   const [loading, setLoading] = React.useState(false);
@@ -62,6 +62,7 @@ const CreateHelmReleaseComponent: React.FC<HelmReleaseFormProps> = props => {
   const [chartNameList, setChartNameList] = React.useState({});
   const [versions, setVersions] = React.useState([]);
   const [selectRepoName, setSelectRepoName] = React.useState(defaultRepoName);
+  const [editLoading, setEditLoading] = React.useState(defaultValues.name !== '');
 
   const [host, setHost] = React.useState('');
 
@@ -162,7 +163,8 @@ const CreateHelmReleaseComponent: React.FC<HelmReleaseFormProps> = props => {
       await coFetchJSON(`${host}/helm/charts/${selectRepoName}_${selectChartName}/versions/${selectedVersion}`).then(res => {
         const entryValue = Object.values(_.get(res, 'indexfile.entries'))[0];
         methods.setValue('packageURL', entryValue[0].urls[0]);
-        setYamlValues(safeDump(_.get(res, 'values')));
+        !editLoading && setYamlValues(safeDump(_.get(res, 'values')));
+        setEditLoading(false);
       });
     };
     versions.length > 0 ? setChartVersion() : methods.setValue('version', { value: defaultVersion, label: defaultVersion });

--- a/frontend/public/components/hypercloud/form/helmreleases/create-helmrelease.tsx
+++ b/frontend/public/components/hypercloud/form/helmreleases/create-helmrelease.tsx
@@ -82,7 +82,7 @@ const CreateHelmReleaseComponent: React.FC<HelmReleaseFormProps> = props => {
     const getUrl = async () => {
       const tempHost = await getHost();
       const namespace = getNamespace(window.location.pathname);
-      setPostUrl(`${tempHost}/helm/ns/${namespace}/releases`);
+      setPostUrl(defaultReleaseName ? `${tempHost}/helm/ns/${namespace}/releases/${defaultReleaseName}` : `${tempHost}/helm/ns/${namespace}/releases`);
     };
     getUrl();
     const fetchHelmChart = async () => {


### PR DESCRIPTION
[refact] create-helmrelease  수정시 post 를 put method 로 변경

수정에서 사용하는 api 가 주소랑 method가 변경되어서 수정했습니다.


[bugfix] helmrelease edit page - 현재 설정 값 가져오는 부분 수정
수정에서는 chart.value 가 아닌 config 가져와야 함