### PR TITLE
[feat] versoin api call 에러 방어 로직 추가, console.log -> console.error 변경

### DIFF
--- a/frontend/packages/console-shared/src/constants/common.ts
+++ b/frontend/packages/console-shared/src/constants/common.ts
@@ -37,6 +37,7 @@ export const COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/
 export const DEV_CATALOG_FILTER_KEY = `${STORAGE_PREFIX}/dev-catalog-filters`;
 export const PINNED_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/pinned-resources`;
 export const LAST_CLUSTER_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-cluster`;
+export const LAST_CLUSTER_HOST_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-cluster-host`;
 
 // Bootstrap user for OpenShift 4.0 clusters
 export const KUBE_ADMIN_USERNAME = 'kube:admin';

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
@@ -3,12 +3,12 @@ import { Helmet } from 'react-helmet';
 import { matchPath, match as RMatch, Redirect } from 'react-router-dom';
 import { Popover, Button } from '@patternfly/react-core';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
-import { StatusBox, Firehose, HintBlock, AsyncComponent, removeQueryArgument } from '@console/internal/components/utils';
+import { StatusBox, Firehose, HintBlock, AsyncComponent, removeQueryArgument, PageHeading } from '@console/internal/components/utils';
 
 import EmptyState from '../EmptyState';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import ProjectsExistWrapper from '../ProjectsExistWrapper';
-import ProjectListPage from '../projects/ProjectListPage';
+//import ProjectListPage from '../projects/ProjectListPage';
 import ConnectedTopologyDataController, { RenderProps } from './TopologyDataController';
 import Topology from './Topology';
 import TopologyShortcuts from './TopologyShortcuts';
@@ -16,6 +16,7 @@ import { LAST_TOPOLOGY_VIEW_LOCAL_STORAGE_KEY } from './components/const';
 
 import './TopologyPage.scss';
 import { TOPOLOGY_SEARCH_FILTER_KEY } from './filters';
+import { useTranslation } from 'react-i18next';
 
 export interface TopologyPageProps {
   match: RMatch<{
@@ -31,16 +32,19 @@ const getTopologyActiveView = () => {
   return localStorage.getItem(LAST_TOPOLOGY_VIEW_LOCAL_STORAGE_KEY);
 };
 
-const EmptyMsg = () => (
-  <EmptyState
-    title="Topology"
-    hintBlock={
-      <HintBlock title="No workloads found">
-        <p>To add content to your project, create an application, component or service using one of these options.</p>
-      </HintBlock>
-    }
-  />
-);
+const EmptyMsg = () => {
+  const { t } = useTranslation();
+  return (
+    <EmptyState
+      title={t('COMMON:MSG_LNB_MENU_191')}
+      hintBlock={
+        <HintBlock title={t('SINGLE:MSG_ADD_CREATFORM_3')}>
+          <p>{t('SINGLE:MSG_ADD_CREATFORM_4')}</p>
+        </HintBlock>
+      }
+    />
+  );
+};
 
 export function renderTopology({ loaded, loadError, data, namespace }: RenderProps) {
   return (
@@ -51,6 +55,18 @@ export function renderTopology({ loaded, loadError, data, namespace }: RenderPro
     </StatusBox>
   );
 }
+
+const SelectNamespacePage = () => {
+  const { t } = useTranslation();
+  return (
+    <>
+      <div className="odc-empty-state__title">
+        <PageHeading title={t('COMMON:MSG_LNB_MENU_191')} />
+        <div className="co-catalog-page__description odc-empty-state__hint-block">{t('COMMON:MSG_LNB_MENU_DESCRIPTION_1')}</div>
+      </div>
+    </>
+  );
+};
 
 export const TopologyPage: React.FC<TopologyPageProps> = ({ match }) => {
   const namespace = match.params.name;
@@ -103,7 +119,7 @@ export const TopologyPage: React.FC<TopologyPageProps> = ({ match }) => {
       >
         <Firehose resources={[{ kind: 'Namespace', prop: 'projects', isList: true }]}>
           <ProjectsExistWrapper title="Topology">
-            {namespace ? showListView ? <AsyncComponent mock={false} match={match} title="" EmptyMsg={EmptyMsg} emptyBodyClass="odc-namespaced-page__content" loader={() => import('@console/internal/components/overview' /* webpackChunkName: "topology-overview" */).then(m => m.Overview)} /> : <ConnectedTopologyDataController match={match} render={renderTopology} /> : <ProjectListPage title="Topology">Select a project to view the topology</ProjectListPage>}
+            {namespace ? showListView ? <AsyncComponent mock={false} match={match} title="" EmptyMsg={EmptyMsg} emptyBodyClass="odc-namespaced-page__content" loader={() => import('@console/internal/components/overview' /* webpackChunkName: "topology-overview" */).then(m => m.Overview)} /> : <ConnectedTopologyDataController match={match} render={renderTopology} /> : <SelectNamespacePage />}
           </ProjectsExistWrapper>
         </Firehose>
       </NamespacedPage>

--- a/frontend/public/components/hypercloud/utils/ingress-utils.ts
+++ b/frontend/public/components/hypercloud/utils/ingress-utils.ts
@@ -5,6 +5,7 @@ import { coFetchJSON } from '@console/internal/co-fetch';
 import { selectorToString } from '@console/internal/module/k8s/selector';
 import { initializationForMenu } from '@console/internal/components/hypercloud/utils/menu-utils';
 import { getServicePort } from '@console/internal/actions/ui';
+import { LAST_CLUSTER_HOST_LOCAL_STORAGE_KEY } from '@console/shared/src/constants';
 
 export const DEFAULT_INGRESS_LABEL_KEY = 'ingress.tmaxcloud.org/name';
 
@@ -46,7 +47,7 @@ export const getIngressUrl = async (label: string, endPoint?: string) => {
 const setSingleClusterBasePath = async () => {
   const host = await getIngressHost('multicluster');
   if (host) {
-    window.SERVER_FLAGS.singleClusterBasePath = `https://${host}/`;
+    sessionStorage.setItem(LAST_CLUSTER_HOST_LOCAL_STORAGE_KEY, `https://${host}/`);
   }
 };
 

--- a/frontend/public/components/hypercloud/utils/langs/i18n.js
+++ b/frontend/public/components/hypercloud/utils/langs/i18n.js
@@ -22,9 +22,9 @@ export const getLanguage = () => {
 };
 
 export const getI18nResources = async () => {
-  const data = await coFetchJSON('/api/hypercloud/version').catch(e => console.error(e));
-  const k8sVersion = data ? data.find(item => item.name === 'Kubernetes')?.version : DEFAULT_K8S_VERSION;
-  const version = k8sVersion && k8sVersion.split('.').length > 1 && k8sVersion !== DEFAULT_K8S_VERSION ? `${k8sVersion.split('.')[0]}.${k8sVersion.split('.')[1]}` : DEFAULT_K8S_VERSION;
+  const data = await coFetchJSON('/api/kubernetes/version').catch(e => console.error(e));
+  const k8sVersion = data ? data.gitVersion : DEFAULT_K8S_VERSION;
+  const version = k8sVersion && k8sVersion.split('.').length > 1 ? `${k8sVersion.split('.')[0]}.${k8sVersion.split('.')[1]}` : DEFAULT_K8S_VERSION;
   if (VERSION.includes(version) && version !== DEFAULT_K8S_VERSION) {
     const en = await import(`./k8s-${version}/${LANG[0]}.json`);
     const ko = await import(`./k8s-${version}/${LANG[1]}.json`);

--- a/frontend/public/components/hypercloud/utils/langs/i18n.js
+++ b/frontend/public/components/hypercloud/utils/langs/i18n.js
@@ -22,7 +22,7 @@ export const getLanguage = () => {
 };
 
 export const getI18nResources = async () => {
-  const data = await coFetchJSON('/api/hypercloud/version').catch(e=>console.log(e));
+  const data = await coFetchJSON('/api/hypercloud/version').catch(e => console.error(e));
   const k8sVersion = data ? data.find(item => item.name === 'Kubernetes')?.version : DEFAULT_K8S_VERSION;
   const version = k8sVersion && k8sVersion.split('.').length > 1 && k8sVersion !== DEFAULT_K8S_VERSION ? `${k8sVersion.split('.')[0]}.${k8sVersion.split('.')[1]}` : DEFAULT_K8S_VERSION;
   if (VERSION.includes(version) && version !== DEFAULT_K8S_VERSION) {

--- a/frontend/public/components/hypercloud/utils/langs/i18n.js
+++ b/frontend/public/components/hypercloud/utils/langs/i18n.js
@@ -22,9 +22,9 @@ export const getLanguage = () => {
 };
 
 export const getI18nResources = async () => {
-  const data = await coFetchJSON('/api/hypercloud/version');
-  const k8sVersion = data.find(item => item.name === 'Kubernetes')?.version;
-  const version = k8sVersion && k8sVersion.split('.').length > 1 ? `${k8sVersion.split('.')[0]}.${k8sVersion.split('.')[1]}` : DEFAULT_K8S_VERSION;
+  const data = await coFetchJSON('/api/hypercloud/version').catch(e=>console.log(e));
+  const k8sVersion = data ? data.find(item => item.name === 'Kubernetes')?.version : DEFAULT_K8S_VERSION;
+  const version = k8sVersion && k8sVersion.split('.').length > 1 && k8sVersion !== DEFAULT_K8S_VERSION ? `${k8sVersion.split('.')[0]}.${k8sVersion.split('.')[1]}` : DEFAULT_K8S_VERSION;
   if (VERSION.includes(version) && version !== DEFAULT_K8S_VERSION) {
     const en = await import(`./k8s-${version}/${LANG[0]}.json`);
     const ko = await import(`./k8s-${version}/${LANG[1]}.json`);

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -8,6 +8,7 @@ import { inject } from './inject';
 import { makeReduxID, makeQuery, makeReduxIDforNonK8sResource } from './k8s-watcher';
 import * as k8sActions from '../../actions/k8s';
 import { kindObj } from '.';
+import { StatusBox } from './status-box';
 
 const shallowMapEquals = (a, b) => {
   if (a === b || (a.size === 0 && b.size === 0)) {
@@ -269,7 +270,7 @@ export const Firehose = connect(
         );
         return <ConnectToState reduxes={reduxes}>{children}</ConnectToState>;
       }
-      return null;
+      return <StatusBox noCrd={true} />;
     }
   },
 );

--- a/frontend/public/components/utils/status-box.tsx
+++ b/frontend/public/components/utils/status-box.tsx
@@ -97,8 +97,16 @@ const Data: React.FC<DataProps> = props => {
 Data.displayName = 'Data';
 
 export const StatusBox: React.FC<StatusBoxProps> = props => {
-  const { loadError, loaded, skeleton, ...dataProps } = props;
+  const { loadError, loaded, skeleton, noCrd, ...dataProps } = props;
   const { t } = useTranslation();
+
+  if (noCrd) {
+    return (
+      <div className="co-m-pane__body">
+        <h1 className="co-m-pane__heading co-m-pane__heading--center">{t('COMMON:MSG_COMMON_ERROR_MESSAGE_42')}</h1>
+      </div>
+    );
+  }
 
   if (loadError) {
     const status = _.get(loadError, 'response.status');
@@ -187,4 +195,5 @@ type StatusBoxProps = {
   NoDataEmptyMsg?: React.ComponentType;
   EmptyMsg?: React.ComponentType;
   children?: React.ReactNode;
+  noCrd?: boolean;
 };

--- a/frontend/public/hypercloud/perspectives.tsx
+++ b/frontend/public/hypercloud/perspectives.tsx
@@ -14,6 +14,7 @@ import * as SelectedMasterClusterIcon from '@console/internal/imgs/hypercloud/ln
 import * as SelectedSingleClusterIcon from '@console/internal/imgs/hypercloud/lnb/filled/single_cluster_filled.svg';
 import * as SelectedDeveloperIcon from '@console/internal/imgs/hypercloud/lnb/filled/developer_filled.svg';
 import * as SelectedBaremetalIcon from '@console/internal/imgs/hypercloud/lnb/filled/baremetal_filled.svg';
+import { LAST_CLUSTER_HOST_LOCAL_STORAGE_KEY } from '@console/shared/src/constants';
 
 export enum PerspectiveType {
   MASTER = 'MASTER',
@@ -41,7 +42,7 @@ export const isMasterClusterPerspective = () => {
   return getActivePerspective() == PerspectiveType.MASTER;
 };
 export const getSingleClusterFullBasePath = () => {
-  return `${window.SERVER_FLAGS.singleClusterBasePath}api/${getActiveCluster()}`;
+  return `${sessionStorage.getItem(LAST_CLUSTER_HOST_LOCAL_STORAGE_KEY)}api/${getActiveCluster()}`;
 };
 
 /* 임시 */


### PR DESCRIPTION
version 정보 get api /api/hypercloud/version 에서 /api/kubernetes/version 으로 변경

`const data = await coFetchJSON('/api/kubernetes/version').catch(e => console.error(e));`
html 로 response 가 와도 data 는 undefined 로 나와서 방어로직이 정상 동작을 합니다.
coFetchJSON 에서 json 이 아닌 값이 오면 catch 로 보내서 다음 로그가 생기는것을 확인했습니다.
 SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON


[bugfix] single cluster 에서 사용하는 host 정보 저장 session storage 로 변경