### PR TITLE
helm repository 등 예외 처리

### DIFF
--- a/frontend/public/actions/utils/nonk8s-utils.tsx
+++ b/frontend/public/actions/utils/nonk8s-utils.tsx
@@ -72,6 +72,9 @@ export const nonK8sListResult = async (id: string, response: any) => {
   const kind = getKind(id);
   switch (kind) {
     case 'HelmRepository':
+      if (response.error) {
+        return [];
+      }
       await (async () => {
         await Promise.all(
           response.repoInfo.map(async repoinfo => {
@@ -88,8 +91,14 @@ export const nonK8sListResult = async (id: string, response: any) => {
       })();
       return response.repoInfo;
     case 'HelmRelease':
+      if (response.error) {
+        return [];
+      }
       return response.release;
     case 'HelmChart':
+      if (response.error) {
+        return [];
+      }
       let tempList = [];
       let entriesvalues = Object.values(_.get(response, 'indexfile.entries'));
       entriesvalues.map(value => {

--- a/frontend/public/components/hypercloud/helmrelease.tsx
+++ b/frontend/public/components/hypercloud/helmrelease.tsx
@@ -242,7 +242,7 @@ const HelmReleaseDetails: React.FC<HelmReleaseDetailsProps> = ({ obj: release })
                   .map(k => {
                     return (
                       <tr key={'row-' + k}>
-                        <td style={{ padding: '5px' }}>{t(modelFor(k).i18nInfo.label)}</td>
+                        <td style={{ padding: '5px' }}>{modelFor(k) ? ResourceLabel(modelFor(k), t) : k}</td>
                         <td style={{ padding: '5px' }}>
                           <ResourceLink kind={k} name={release.objects[k] as string} namespace={release.namespace} />
                         </td>


### PR DESCRIPTION
[bugfix] helm api - 예외 처리
- helm api 응답에서 헬름 레포가 없어서  error 가 있는 경우 빈 배열로 반환
`{"error":"No helm repository is added","description":"you need to add at least one helm repository"}`

[bugfix] helmrelease detail page - 리소스 테이블 에서 model 없는 리소스 예외 처리
- helm release detail page 하단 헬름에서 생생한 리소스 중 model 이 없는 리소스가 있을때 생기는 에러 예외 처리