### PR TITLE
[bugfix] 레디스 리스트 페이지 resourcelink에 namespace 추가

### DIFF
--- a/frontend/public/components/hypercloud/redis.tsx
+++ b/frontend/public/components/hypercloud/redis.tsx
@@ -48,7 +48,7 @@ const tableProps: TableProps = {
     },
     {
       children: obj.spec.redisConfig &&
-        <ResourceLink kind="ConfigMap" name={obj.spec.redisConfig.additionalRedisConfig} title={obj.spec.redisConfig.additionalRedisConfig} />
+        <ResourceLink kind="ConfigMap" name={obj.spec.redisConfig.additionalRedisConfig} namespace={obj.metadata.namespace} title={obj.spec.redisConfig.additionalRedisConfig} />
     },
     {
       children: <Timestamp timestamp={obj.metadata.creationTimestamp} />,


### PR DESCRIPTION
레디스 리스트 페이지의 ResourceLink 컴포넌트에 누락된 namespace 추가.