### PR TITLE
[feat][patch][IMS 1833225] 시크릿 키/값 수정시에도 데이터값 표시에 토큰값을 64 인코딩하여 적용

### DIFF
--- a/frontend/public/components/configmap-and-secret-data.tsx
+++ b/frontend/public/components/configmap-and-secret-data.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Base64 } from 'js-base64';
+//import { Base64 } from 'js-base64';
 import { saveAs } from 'file-saver';
 import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
 import { Button } from '@patternfly/react-core';
@@ -71,9 +71,8 @@ export const SecretValue: React.FC<SecretValueProps> = ({ value, reveal, encoded
     return <span className="text-muted">No value</span>;
   }
 
-  const decodedValue = encoded ? Base64.decode(value) : value;
-  const visibleValue = reveal ? decodedValue : <MaskedData />;
-  return <CopyToClipboard value={decodedValue} visibleValue={visibleValue} />;
+  const visibleValue = reveal ? value : <MaskedData />;
+  return <CopyToClipboard value={value} visibleValue={visibleValue} />;
 };
 SecretValue.displayName = 'SecretValue';
 

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -975,7 +975,7 @@ const KeyValueEntryForm = withTranslation()(
           </div>
           <div className="form-group">
             <div>
-              <DroppableFileInput onChange={this.onValueChange} inputFileData={this.state.value} id={`${this.props.id}-value`} label={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_4')} inputFieldHelpText={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_6')} />
+              <DroppableFileInput onChange={this.onValueChange} inputFileData={this.state.value} id={`${this.props.id}-value`} textareaFieldHelpText={t('SINGLE:MSG_SECRETS_CREATEFORM_DIV2_1')} label={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_4')} inputFieldHelpText={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_6')} />
             </div>
           </div>
         </div>

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -123,7 +123,7 @@ export const withSecretForm = (SubForm, modal?: boolean) =>
           inProgress: false,
           type: defaultSecretType,
           stringData: _.mapValues(_.get(props.obj, 'data'), value => {
-            return value ? Base64.decode(value) : '';
+            return value;
           }),
           disableForm: false,
         };


### PR DESCRIPTION
What:이전에 진행 했던 IMS 1833225 에 수정시에도 데이터값 표시에 토큰값을 64 인코딩하여 적용하였습니다.
Why: ims action 으로 수정시에도 데이터값 표시에 토큰값을 64 인코딩하여 적용요청이 왔습니다.
How:
<img width="808" alt="image" src="https://user-images.githubusercontent.com/82989054/203445369-f057d5a5-4a5b-4224-92e7-41f953a4f2b3.png">
