### PR TITLE
IMS 290754 파이프라인 taskRef 없을시 예외처리, IMS 294263 헬름리포지터리 상세페이지 내 헬름차트 페이지 무한 로딩 수정

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
@@ -84,24 +84,26 @@ export const PipelineVisualizationTask: React.FC<PipelineVisualizationTaskProp> 
     return taskComponent;
   }
 
-  let resources;
-  if (task.taskRef.kind === ClusterTaskModel.kind) {
-    resources = [
-      {
-        kind: referenceForModel(ClusterTaskModel),
-        name: task.taskRef.name,
-        prop: 'task',
-      },
-    ];
-  } else {
-    resources = [
-      {
-        kind: referenceForModel(TaskModel),
-        name: task.taskRef.name,
-        namespace,
-        prop: 'task',
-      },
-    ];
+  let resources = [];
+  if (task.taskRef) {
+    if (task.taskRef.kind === ClusterTaskModel.kind) {
+      resources = [
+        {
+          kind: referenceForModel(ClusterTaskModel),
+          name: task.taskRef.name ? task.taskRef.name : task.name,
+          prop: 'task',
+        },
+      ];
+    } else {
+      resources = [
+        {
+          kind: referenceForModel(TaskModel),
+          name: task.taskRef.name ? task.taskRef.name : task.name,
+          namespace,
+          prop: 'task',
+        },
+      ];
+    }
   }
   return <Firehose resources={resources}>{taskComponent}</Firehose>;
 };

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -97,14 +97,20 @@ const sortTasksByRunAfterAndFrom = (
     let flag = -1;
     if (conditions.hasRunAfterDependency(output[i])) {
       for (let j = 0; j < output.length; j++) {
-        if (i < j && output[j].taskRef.name === output[i].runAfter[output[i].runAfter.length - 1]) {
-          flag = j;
+        if (output[j].taskRef) {          
+          const taskName = output[j].taskRef.name ? output[j].taskRef.name : output[j].name;
+          if (i < j && taskName === output[i].runAfter[output[i].runAfter.length - 1]) {
+            flag = j;
+          }
         }
       }
     } else if (conditions.hasFromDependency(output[i])) {
       for (let j = i + 1; j < output.length; j++) {
-        if (output[j].taskRef.name === output[i].resources.inputs[0].from[0]) {
-          flag = j;
+        if (output[j].taskRef) {          
+          const taskName = output[j].taskRef.name ? output[j].taskRef.name : output[j].name;
+          if (taskName === output[i].resources.inputs[0].from[0]) {
+            flag = j;
+          }
         }
       }
     }
@@ -184,11 +190,14 @@ export const getPipelineTasks = (
       let flag = out.length - 1;
       for (let i = 0; i < out.length; i++) {
         for (const t of out[i]) {
-          if (
-            t.taskRef.name === task.resources.inputs[0].from[0] ||
-            t.name === task.resources.inputs[0].from[0]
-          ) {
-            flag = i;
+          if (t.taskRef) {
+            const taskName = t.taskRef.name ? t.taskRef.name : t.name;
+            if (
+              taskName === task.resources.inputs[0].from[0] ||
+              t.name === task.resources.inputs[0].from[0]
+            ) {
+              flag = i;
+            }
           }
         }
       }
@@ -216,8 +225,11 @@ export const getPipelineTasks = (
       let flag = out.length - 1;
       for (let i = 0; i < out.length; i++) {
         for (const t of out[i]) {
-          if (t.taskRef.name === task.runAfter[0] || t.name === task.runAfter[0]) {
-            flag = i;
+          if (t.taskRef) {
+            const taskName = t.taskRef.name ? t.taskRef.name : t.name;
+            if (taskName === task.runAfter[0] || t.name === task.runAfter[0]) {
+              flag = i;
+            }
           }
         }
       }

--- a/frontend/public/components/hypercloud/helmchart.tsx
+++ b/frontend/public/components/hypercloud/helmchart.tsx
@@ -152,3 +152,36 @@ export const HelmChartDetailsList: React.FC<HelmChartDetailsListProps> = ({ entr
 type HelmChartDetailsListProps = {
   entry: any;
 };
+
+const chartTableProps = (repoName: string): TableProps => {
+  return {
+    header: [
+      {
+        title: 'COMMON:MSG_MAIN_TABLEHEADER_1',
+        sortField: 'name',
+      },
+      {
+        title: 'COMMON:MSG_MAIN_TABLEHEADER_141',
+        sortField: 'version',
+      },
+    ],
+    row: (obj: any) => {
+      return [
+        {
+          children: <ResourceLink manualPath={`/helmcharts/${repoName}/${obj.name}`} kind={HelmChartModel.kind} name={obj.name} />,
+        },
+        {
+          children: obj.version,
+        },
+      ];
+    },
+  };
+};
+export const ChartListPage: React.FC<ChartListPageProps> = props => {
+  const { repoName } = props;
+  return <ListPage tableProps={chartTableProps(repoName)} kind={HelmChartModel.kind} hideLabelFilter={true} customData={{ nonK8sResource: true, kindObj: HelmChartModel, helmRepo: name }} isK8sResource={false} />;
+};
+type ChartListPageProps = {
+  match?: any;
+  repoName?: string;
+};

--- a/frontend/public/components/hypercloud/helmrepository.tsx
+++ b/frontend/public/components/hypercloud/helmrepository.tsx
@@ -3,14 +3,14 @@ import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { sortable, compoundExpand } from '@patternfly/react-table';
-import { SectionHeading, Timestamp, detailsPage, navFactory, Kebab, KebabOption, KebabAction, Page, ResourceLink } from '@console/internal/components/utils';
-import { TableProps } from './utils/default-list-component';
+import { SectionHeading, Timestamp, detailsPage, navFactory, Kebab, KebabOption, KebabAction, ResourceLink } from '@console/internal/components/utils';
 import { DetailsPage, ListPage, DetailsPageProps, Table } from '../factory';
 import { deleteModal, helmrepositoryUpdateModal } from '../modals';
 import { TFunction } from 'i18next';
 import { ExpandableInnerTable } from './utils/expandable-inner-table';
 import { HelmRepositoryModel, HelmChartModel } from '@console/internal/models/hypercloud/helm-model';
 import { helmAPI } from '@console/internal/actions/utils/nonk8s-utils';
+import { ChartListPage } from './helmchart';
 
 const kind = HelmRepositoryModel.kind;
 
@@ -198,43 +198,6 @@ const HelmRepositoriesList: React.FC = props => {
 HelmRepositoriesList.displayName = 'HelmRepositoriesList';
 
 const { details } = navFactory;
-const chartsPage: (c?: React.ComponentType<any>) => Page = component => ({
-  href: 'charts',
-  name: 'COMMON:MSG_MAIN_TABLEHEADER_142',
-  component,
-});
-const chartTableProps = (repoName: string): TableProps => {
-  return {
-    header: [
-      {
-        title: 'COMMON:MSG_MAIN_TABLEHEADER_1',
-        sortField: 'name',
-      },
-      {
-        title: 'COMMON:MSG_MAIN_TABLEHEADER_141',
-        sortField: 'version',
-      },
-    ],
-    row: (obj: any) => {
-      return [
-        {
-          children: <ResourceLink manualPath={`/helmcharts/${repoName}/${obj.name}`} kind={HelmChartModel.kind} name={obj.name} />,
-        },
-        {
-          children: obj.version,
-        },
-      ];
-    },
-  };
-};
-
-type ChartListPageProps = {
-  name: string;
-};
-export const ChartListPage: React.FC<ChartListPageProps> = props => {
-  const { name } = props;
-  return <ListPage tableProps={chartTableProps(name)} kind={HelmChartModel.kind} hideLabelFilter={true} customData={{ nonK8sResource: true, kindObj: HelmChartModel, helmRepo: name }} isK8sResource={false} />;
-};
 
 export const HelmrepositoryDetailsPage: React.FC<DetailsPageProps> = props => {
   const { t } = useTranslation();
@@ -268,7 +231,14 @@ export const HelmrepositoryDetailsPage: React.FC<DetailsPageProps> = props => {
     <DetailsPage
       {...props}
       kind={kind}
-      pages={[details(detailsPage(HelmRepositoryDetails)), chartsPage(() => ChartListPage({ name }))]}
+      pages={[
+        details(detailsPage(HelmRepositoryDetails)),
+        {
+          href: 'charts',
+          name: 'COMMON:MSG_MAIN_TABLEHEADER_142',          
+          component: ChartListPage,
+        },
+      ]}
       customData={{ helmRepo: props.match?.params?.repo, nonK8sResource: true, kindObj: HelmRepositoryModel }}
       name={props.match?.params?.name}
       isK8sResource={false}

--- a/frontend/public/components/hypercloud/pipeline-approval.tsx
+++ b/frontend/public/components/hypercloud/pipeline-approval.tsx
@@ -99,7 +99,7 @@ export const PipelineApprovalDetailsList: React.FC<PipelineApprovalDetailsListPr
       </DetailsItem>
       <DetailsItem label={t('COMMON:MSG_DETAILS_TABDETAILS_19')} obj={ds} path="spec.users">
         {ds.spec.users.map(user => (
-          <div>{user}</div>
+          <div>{typeof user === 'string' ? user : user.name}</div>
         ))}
       </DetailsItem>
       {ds.status.result === 'Rejected' && (

--- a/frontend/public/components/hypercloud/pipeline.tsx
+++ b/frontend/public/components/hypercloud/pipeline.tsx
@@ -84,7 +84,7 @@ export const PipelineDetailsList: React.FC<PipelineDetailsListProps> = ({ ds: pi
     .filter((pipelineTask: PipelineTask) => !!pipelineTask.taskRef)
     .map(task => ({
       model: getResourceModelFromTaskKind(task.taskRef.kind),
-      name: task.taskRef.name,
+      name: task.taskRef.name ? task.taskRef.name : task.name,
       displayName: task.name,
     }));
 


### PR DESCRIPTION
[bugfix][patch][IMS 290754] 파이프라인 승인 user 값 string list 에서 object list 로 변경되어 생긴 문제 수정

파이프라인 승인 user 값 string list 에서 object list 로 변경되어 sting 인지 확인하고 아니면 object 의 name 값으로 나오게 변경함

[bugfix][patch][IMS 290754] 파이프라인 taskRef 가 없는 경우 예외 처리
taskRef 가 없는 경우는 해당 값을 사용하는 부분 넘어가도록 변경함


[bugfix][patch][IMS 294263]헬름 리포지터리 상세페이지 차트 탭 무한로딩 수정
상세페이지의 pages 로 입력한 Page 객체 내부의 component 를 즉시실행 함수로 넣었더니 검색시 무한로딩 되는 현상이 발생
component 를 ChartListPage 로 변경
ChartListPage 위치 변경