### PR TITLE
[feat][patch][IMS 294273] 헬름차트 메뉴에서 이름 중복 리소스 가져오지 않는 현상 수정

### DIFF
--- a/frontend/public/reducers/k8s.ts
+++ b/frontend/public/reducers/k8s.ts
@@ -53,7 +53,8 @@ const loadList = (oldList, resources, id?) => {
   const existingKeys = new Set(oldList.keys());
   return oldList.withMutations((list) => {
     (resources || []).forEach((r) => {
-      const qualifiedName = isNonK8SResource(id) ? (r.namespace ? `(${r.namespace})-` : '') + r.name : getQN(r);
+      const repoName = r.repo?.name ? r.repo.name : '';
+      const qualifiedName = isNonK8SResource(id) ? (r.namespace ? `(${r.namespace})-` : '') + r.name + repoName : getQN(r);
       existingKeys.delete(qualifiedName);
       const next = fromJS(r);
       const current = list.get(qualifiedName);


### PR DESCRIPTION
What: 헬름차트 메뉴에서 이름 중복 리소스 가져오지 않는 현상을 수정했습니다.
Why: IMS 294273로 문제를 전달 받았습니다.
How: list.set(qualifiedName, next); 부분에서 qualifiedName이 중복이 된다면 같은 이름의 네임을 가진 리소스가 없어집니다.
헬름 리포지터리 네임을 인자를 추가하여 유니크하게 리소스를 추가 할수 있게 하였습니다. 

<img width="757" alt="스크린샷 2022-11-28 오전 10 15 13" src="https://user-images.githubusercontent.com/82989054/204180996-b7109ca5-ba07-47b3-ad0d-bdf7d8c4dcdb.png">

이전에는 하나만 볼수있었던 harbor 를 2개 다 볼수 있게 되었습니다.

<img width="615" alt="스크린샷 2022-11-28 오전 10 12 07" src="https://user-images.githubusercontent.com/82989054/204181006-276125bd-804b-49c7-bb15-db0012bd94f5.png">

