### PR TITLE
[feat][patch][IMS 294302] HPA메트릭 수치 표시가 안되는 문제 수정

### DIFF
--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -56,20 +56,20 @@ const podRow = (metric, current, key) => {
 };
 
 const getResourceUtilization = currentMetric => {
-  const currentUtilization = _.get(currentMetric, 'resource.currentAverageUtilization');
+  const currentUtilization = _.get(currentMetric, 'resource.current.averageUtilization');
 
   // Use _.isFinite so that 0 evaluates to true, but null / undefined / NaN don't
   if (!_.isFinite(currentUtilization)) {
     return null;
   }
 
-  const currentAverageValue = _.get(currentMetric, 'resource.currentAverageValue');
+  const currentAverageValue = _.get(currentMetric, 'resource.current.averageValue');
   // Only show currentAverageValue in parens if set and non-zero to avoid things like "0% (0)"
   return currentAverageValue && currentAverageValue !== '0' ? `${currentUtilization}% (${currentAverageValue})` : `${currentUtilization}%`;
 };
 
 const resourceRow = (metric, current, key) => {
-  const targetUtilization = metric.resource.targetAverageUtilization;
+  const targetUtilization = metric.resource.target.averageUtilization;
   const resourceLabel = `resource ${metric.resource.name}`;
   const type = targetUtilization ? (
     <>
@@ -78,7 +78,7 @@ const resourceRow = (metric, current, key) => {
   ) : (
     resourceLabel
   );
-  const currentValue = targetUtilization ? getResourceUtilization(current) : _.get(current, 'resource.currentAverageValue');
+  const currentValue = targetUtilization ? getResourceUtilization(current) : _.get(current, 'resource.current.averageValue');
   const targetValue = targetUtilization ? `${targetUtilization}%` : metric.resource.targetAverageValue;
 
   return <MetricsRow key={key} type={type} current={currentValue} target={targetValue} />;


### PR DESCRIPTION
What: HPA메트릭 수치 표시가 안되는 문제를 수정하였습니다
<img width="666" alt="스크린샷 2022-11-30 오전 10 05 42" src="https://user-images.githubusercontent.com/82989054/204686701-c0fb6376-34fd-4a6a-95ce-a6cc5f934de4.png">
.

Why:ims이슈 처리가 요청되었습니다.
How:객체의 구조를 보니 스트링과 오브젝트의 구조가 잘못들어가 있었습니다.