### PR TITLE
[feat][IMS 295182] 싱글 클러스터 검색 리스트 수정

### DIFF
--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -6,10 +6,11 @@ import * as classNames from 'classnames';
 import * as fuzzy from 'fuzzysearch';
 
 import { Dropdown, ResourceIcon } from './utils';
-import { apiVersionForReference, K8sKind, K8sResourceKindReference, modelFor, referenceForModel } from '../module/k8s';
+import { apiVersionForReference, K8sKind, K8sResourceKindReference, K8sVerb, kindToAbbr, modelFor, pluralizeKind, referenceForModel } from '../module/k8s';
 import { Badge, Checkbox } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-
+import { coFetchJSON } from '@console/internal/co-fetch';
+import { isSingleClusterPerspective } from '@console/internal/hypercloud/perspectives';
 // Blacklist known duplicate resources.
 const blacklistGroups = ImmutableSet([
   // Prefer rbac.authorization.k8s.io/v1, which has the same resources.
@@ -20,6 +21,8 @@ const blacklistResources = ImmutableSet([
   // Prefer core/v1
   'events.k8s.io/v1beta1.Event',
 ]);
+
+const ADMIN_RESOURCES = new Set(['roles', 'rolebindings', 'clusterroles', 'clusterrolebindings', 'thirdpartyresources', 'nodes', 'secrets']);
 
 const DropdownItem: React.SFC<DropdownItemProps> = ({ model, showGroup, checked }) => (
   <>
@@ -60,8 +63,70 @@ const DropdownResourceItem: React.SFC<DropdownResourceItemProps> = ({ name, chec
 const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
   const { selected, onChange, allModels, showAll, className, preferredVersions, type } = props;
   const { t } = useTranslation();
+  const [models, setModels] = React.useState(allModels);
+  const [preferredVersionsState, setPreferredVersionsState] = React.useState(preferredVersions);
+  async function inSingle() {
+    await coFetchJSON(`/api/kubernetes/apis`).then(res => {
+      const preferredVersions = res.groups.map(group => group.preferredVersion);
+      const all: Promise<APIResourceList>[] = _.flatten(res.groups.map(group => group.versions.map(version => `/apis/${version.groupVersion}`)))
+        .concat(['/api/v1'])
+        .map(p => coFetchJSON(`/api/kubernetes${p}`).catch(err => err));
+      return Promise.all(all).then(data => {
+        const resourceSet = new Set<string>();
+        const namespacedSet = new Set<string>();
+        data.forEach(
+          d =>
+            d.resources &&
+            d.resources.forEach(({ namespaced, name }) => {
+              resourceSet.add(name);
+              namespaced && namespacedSet.add(name);
+            }),
+        );
+        const allResources = [...resourceSet].sort();
 
-  const resources = allModels
+        const safeResources = [];
+        const adminResources = [];
+
+        const defineModels = (list: APIResourceList): K8sKind[] => {
+          const groupVersionParts = list.groupVersion.split('/');
+          const apiGroup = groupVersionParts.length > 1 ? groupVersionParts[0] : null;
+          const apiVersion = groupVersionParts.length > 1 ? groupVersionParts[1] : list.groupVersion;
+          return list.resources
+            .filter(({ name }) => !name.includes('/'))
+            .map(({ name, singularName, namespaced, kind, verbs, shortNames }) => {
+              return {
+                kind,
+                namespaced,
+                verbs,
+                shortNames,
+                label: kind,
+                plural: name,
+                apiVersion,
+                abbr: kindToAbbr(kind),
+                ...(apiGroup ? { apiGroup } : {}),
+                labelPlural: pluralizeKind(kind),
+                path: name,
+                id: singularName,
+                crd: true,
+              };
+            });
+        };
+        allResources.forEach(r => (ADMIN_RESOURCES.has(r.split('/')[0]) ? adminResources.push(r) : safeResources.push(r)));
+        const singleModels = _.flatten(data.filter(d => d.resources).map(defineModels));
+        let obj = {};
+        singleModels.forEach(element => {
+          obj[element.apiGroup + '~' + element.apiVersion + '~' + element.kind] = element;
+        });
+        setModels(ImmutableMap(obj));
+        setPreferredVersionsState(preferredVersions);
+      });
+    });
+  }
+  React.useEffect(() => {
+    isSingleClusterPerspective() && inSingle();
+  }, []);
+
+  const resources = models
     .filter(({ apiGroup, apiVersion, kind, verbs }) => {
       // Remove blacklisted items.
       if (blacklistGroups.has(apiGroup) || blacklistResources.has(`${apiGroup}/${apiVersion}.${kind}`)) {
@@ -72,16 +137,14 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
       if (!_.isEmpty(verbs) && !_.includes(verbs, 'list')) {
         return false;
       }
-
       // Only show preferred version for resources in the same API group.
-      const preferred = (m: K8sKind) => preferredVersions.some(v => v.groupVersion === apiVersionForReference(referenceForModel(m)));
+      const preferred = (m: K8sKind) => preferredVersionsState.some(v => v.groupVersion === apiVersionForReference(referenceForModel(m)));
       const sameGroupKind = (m: K8sKind) => m.kind === kind && m.apiGroup === apiGroup && m.apiVersion !== apiVersion;
 
-      return !allModels.find(m => sameGroupKind(m) && preferred(m));
+      return !models.find(m => sameGroupKind(m) && preferred(m));
     })
     .toOrderedMap()
     .sortBy(({ kind, apiGroup }) => `${kind} ${apiGroup}`);
-
   // Track duplicate names so we know when to show the group.
   const kinds = resources.groupBy(m => m.kind);
   const isDup = kind => kinds.get(kind).size > 1;
@@ -89,6 +152,7 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
   const isKindSelected = (kind: string) => {
     return _.includes(selected, kind);
   };
+
   // Create dropdown items for each resource.
   const items = resources.map(model => <DropdownItem key={referenceForModel(model)} model={model} showGroup={isDup(model.kind)} checked={isKindSelected(referenceForModel(model))} />) as OrderedMap<string, JSX.Element>;
   // Add an "All" item to the top if `showAll`.
@@ -263,4 +327,26 @@ type DropdownResourceItemProps = {
   name: string;
   checked?: boolean;
   kind: string;
+};
+export type APIResourceList = {
+  kind: 'APIResourceList';
+  apiVersion: 'v1';
+  groupVersion: string;
+  resources?: {
+    name: string;
+    singularName?: string;
+    namespaced?: boolean;
+    kind: string;
+    verbs: K8sVerb[];
+    shortNames?: string[];
+  }[];
+};
+export type DiscoveryResources = {
+  adminResources: string[];
+  allResources: string[];
+  configResources: K8sKind[];
+  modelss: K8sKind[];
+  namespacedSet: Set<string>;
+  preferredVersions: { groupVersion: string; version: string }[];
+  safeResources: string[];
 };


### PR DESCRIPTION
what: 싱글 클러스터 검색페이지의 리스트가
전체 리소스를(마스터 리소스) 띄워주던 것을
싱글클러스터 리소스만 띄워지게 수정했습니다.
<img width="584" alt="스크린샷 2022-12-13 오후 2 48 42" src="https://user-images.githubusercontent.com/82989054/207253822-ec4c48d3-7866-4505-a73a-0df6e57b0944.png">
<img width="798" alt="스크린샷 2022-12-13 오후 2 50 18" src="https://user-images.githubusercontent.com/82989054/207253833-ecf950fc-979f-4e1c-acdc-f5565edfb7e6.png">


why: 검색 페이지는 싱글 클러스터이던지 마스터 클러스터 이던지 구분하지않고 페이지를 뛰워주는 페이지였습니다. 때문에 전체 리소스를 가공한 함수에서 리덕스를 이용하여 그냥 가져와서 리소스 리스트를 구성하는 방식으로 구동이 되고 있었습니다.
how: 싱글 클러스터의 리소스를 받아온 다음 드롭다운에 맞는 형식으로 가공한다음 랜더링 하도록 하였습니다.